### PR TITLE
Compile es6 and template strings with babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "private": true,
+  "license": "MIT",
   "scripts": {
     "start": "cd packages/tux-example-site && npm start",
     "postinstall": "lerna bootstrap",
@@ -21,8 +23,6 @@
     "@types/react-addons-css-transition-group": "^15.0.1",
     "@types/react-dom": "^0.14.21",
     "babel-jest": "^18.0.0",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.22.0",
-    "babel-plugin-transform-react-jsx-self": "^6.22.0",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.22.0",
     "del": "^2.2.2",
@@ -43,21 +43,10 @@
     "yargs": "^6.6.0"
   },
   "babel": {
-    "presets": [
-      "react"
-    ],
-    "plugins": [
-      "styled-jsx/babel"
-    ],
     "env": {
-      "development": {
-        "plugins": [
-          "transform-react-jsx-self"
-        ]
-      },
       "test": {
-        "plugins": [
-          "transform-es2015-modules-commonjs"
+        "presets": [
+          "es2015"
         ]
       }
     }

--- a/packages/tux-adapter-contentful/tsconfig.json
+++ b/packages/tux-adapter-contentful/tsconfig.json
@@ -12,7 +12,7 @@
     "removeComments": false,
     "sourceMap": true,
     "strictNullChecks": true,
-    "target": "es5"
+    "target": "es6"
   },
   "include": [
     "./src"

--- a/packages/tux/package.json
+++ b/packages/tux/package.json
@@ -16,6 +16,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "babel-runtime": "^6.23.0",
     "classnames": "^2.2.5",
     "material-ui": "^0.16.7",
     "megadraft": "^0.4.15",

--- a/packages/tux/src/components/TuxBar/TuxBar.tsx
+++ b/packages/tux/src/components/TuxBar/TuxBar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 export interface State {
   user: null | {

--- a/packages/tux/src/components/TuxModalContainer/TuxModalContainer.tsx
+++ b/packages/tux/src/components/TuxModalContainer/TuxModalContainer.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react'
-import * as classNames from 'classnames'
-import * as ReactCSSTransitionGroup from 'react-addons-css-transition-group'
+import React from 'react'
+import classNames from 'classnames'
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group'
 import toggleScroll from './toggle-scroll'
 import { getState, setListener, State as StoreState } from './store'
 

--- a/packages/tux/src/connect.tsx
+++ b/packages/tux/src/connect.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 export interface RefreshProp {
   refresh: () => Promise<void>,

--- a/packages/tux/tsconfig.json
+++ b/packages/tux/tsconfig.json
@@ -12,7 +12,7 @@
     "removeComments": false,
     "sourceMap": true,
     "strictNullChecks": true,
-    "target": "es5"
+    "target": "es6"
   },
   "include": [
     "./src"

--- a/shared/gulpfile.js
+++ b/shared/gulpfile.js
@@ -12,6 +12,23 @@ const merge = require('merge2')
 // tracks incremental builds after a watch triggers.
 const tsProject = ts.createProject('tsconfig.json')
 
+// Configures babel to build es6 code with styled-jsx to es5. Either
+// with or without es2015 module syntax.
+const babelConfig = es2015 => ({
+  plugins: [
+    "styled-jsx/babel",
+    ['transform-runtime', {
+      helpers: false,
+      polyfill: false,
+      regenerator: true,
+    }],
+  ],
+  "presets": [
+    "react",
+    ["es2015", { "modules": es2015 ? false : 'commonjs' }],
+  ],
+})
+
 gulp.task('clean', () => {
   return del(['lib', 'es'])
 })
@@ -27,18 +44,14 @@ gulp.task('build:js', () => {
       .pipe(gulp.dest('lib')),
     tsResult.js
       .pipe(clone())
-      .pipe(babel({
-        plugins: [
-          'transform-es2015-modules-commonjs',
-        ],
-      }))
+      .pipe(babel(babelConfig(false)))
       .pipe(gulp.dest('lib')),
 
     // ES2015 Modules
     tsResult.dts
       .pipe(gulp.dest('es')),
     tsResult.js
-      .pipe(babel())
+      .pipe(babel(babelConfig(true)))
       .pipe(gulp.dest('es')),
   ])
 })

--- a/shared/tsconfig.base.json
+++ b/shared/tsconfig.base.json
@@ -12,7 +12,7 @@
     "removeComments": false,
     "sourceMap": true,
     "strictNullChecks": true,
-    "target": "es5"
+    "target": "es6"
   },
   "exclude": [
     "**/*.spec.{ts,tsx}"


### PR DESCRIPTION
So styled-jsx works.
Needs more babel cleanup. Verify that tests compile the same way.