### PR TITLE
Prop onChange on fields should have value as parameter

### DIFF
--- a/packages/tux/src/components/fields/MarkdownField.tsx
+++ b/packages/tux/src/components/fields/MarkdownField.tsx
@@ -18,7 +18,7 @@ const MarkdownField = ({ id, value, label, onChange }: MarkdownField) => (
       label={label}
       id={id}
       value={value}
-      onChange={onChange}
+      onChange={(event: React.FormEvent<any>) => onChange(event.target.value)}
     />
     <style jsx>{`
         .MarkdownField {

--- a/packages/tux/src/components/fields/TextField.tsx
+++ b/packages/tux/src/components/fields/TextField.tsx
@@ -11,7 +11,13 @@ interface TextField {
 const TextField = ({ id, value, label, onChange }: TextField) => (
   <div className="Input">
     <label className="InputLabel">{label}</label>
-    <input className="InputField" label={label} id={id} value={value} onChange={onChange} />
+    <input
+      className="InputField"
+      id={id}
+      label={label}
+      onChange={(event: React.FormEvent<any>) => onChange(event.target.value)}
+      value={value}
+    />
       <style jsx>{`
         .Input {
           align-items: center;


### PR DESCRIPTION
The onChange event handler in TuxModal should receive value rather than event to be able to send custom data up the chain. It makes things easier when dealing with linked models.