### PR TITLE
Add browse icon

### DIFF
--- a/packages/tux/src/components/fields/BrowseField.tsx
+++ b/packages/tux/src/components/fields/BrowseField.tsx
@@ -55,11 +55,17 @@ class BrowseField extends Component<any, any> {
             line-height: 1.3;
             margin: 0;
             margin-top: 5px;
-            padding: 6px 24px;
+            padding: 6px;
             text-align: center;
             transition: all 0.25s;
             vertical-align: baseline;
             width: 100%;
+          }
+
+          .BrowseField-button::before {
+            content: "\\f068";
+            font-family: "mfg_labs_iconsetregular";
+            padding-right: 10px;
           }
 
           .BrowseField-button:hover {


### PR DESCRIPTION
Icon for Browse button was missing in previous PR.

![image](https://cloud.githubusercontent.com/assets/8494120/23803756/6f2005a0-05af-11e7-92fb-30e17148bcef.png)
