### PR TITLE
Fix uploaded SVG

### DIFF
--- a/packages/tux-example-site/src/components/SellPoints/index.js
+++ b/packages/tux-example-site/src/components/SellPoints/index.js
@@ -8,7 +8,7 @@ const SellPoints = ({ sellPoints }) => (
     {sellPoints && sellPoints.slice(0, 3).map((point, index) => (
       <Editable key={index} model={point} className="SellPoint">
         {point.fields.icon.asset && (
-          <img className="SellPoint-icon" src={point.fields.icon.asset.file.url} alt={point.fields.icon.title}/>
+          <img className="SellPoint-icon" src={`${point.fields.icon.asset.file.url}?w=256`} alt={point.fields.icon.title}/>
         )}
         <h1 className="SellPoint-title">{point.fields.title}</h1>
         <p className="SellPoint-copy">{point.fields.text}</p>


### PR DESCRIPTION
Added ?w=256 to icon src, contentful doesn't seem to process SVGs correctly otherwise.

**No width specified:**
![image](https://cloud.githubusercontent.com/assets/8494120/23901798/b5557492-08b6-11e7-8dae-a7631e55bd8d.png)

**Width specified, 256 to be safe for png icons.**
![image](https://cloud.githubusercontent.com/assets/8494120/23901815/ca606a54-08b6-11e7-8794-86fd13899da8.png)
