### PR TITLE
Handle locale in adapter

### DIFF
--- a/packages/tux-adapter-contentful/src/adapter.ts
+++ b/packages/tux-adapter-contentful/src/adapter.ts
@@ -157,23 +157,18 @@ export class ContentfulAdapter {
 
     const upload = await this.managementApi.createUpload(file)
     if (upload.sys) {
-      const localeName = 'en-US'
       const assetBody = {
         fields: {
-          title: {
-            [localeName]: title,
-          },
+          title: title,
           file: {
-            [localeName]: {
-              contentType: file.type,
-              fileName: file.name,
-              uploadFrom: {
-                sys: {
-                  type: 'Link',
-                  linkType: 'Upload',
-                  id: upload.sys.id,
-                },
-              }
+            contentType: file.type,
+            fileName: file.name,
+            uploadFrom: {
+              sys: {
+                type: 'Link',
+                linkType: 'Upload',
+                id: upload.sys.id,
+              },
             }
           }
         }
@@ -184,18 +179,14 @@ export class ContentfulAdapter {
     return null
   }
 
-  async createAssetFromUrl(url: string, fileName: string, localeName: string, title: string) {
+  async createAssetFromUrl(url: string, fileName: string, title: string) {
     const assetBody = {
       fields: {
-        title: {
-          [localeName]: title
-        },
+        title: title,
         file: {
-          [localeName]: {
-            contentType: 'image/jpeg',
-            fileName,
-            upload: url,
-          }
+          contentType: 'image/jpeg',
+          fileName,
+          upload: url,
         }
       }
     }
@@ -208,7 +199,7 @@ export class ContentfulAdapter {
       throw new Error('Manager api not defined, please log in to save.')
     }
 
-    const asset = await this.managementApi.createAsset(body)
+    const asset = await this.managementApi.createAsset(injectLocale(body))
     if (asset) {
       await this.managementApi.processAsset(
         asset.sys.id,

--- a/packages/tux-adapter-contentful/src/adapter.ts
+++ b/packages/tux-adapter-contentful/src/adapter.ts
@@ -2,6 +2,8 @@ import QueryApi from './query-api'
 import ManagementApi from './management-api'
 import generateEditorSchema from './editors'
 
+import { extractLocale } from './locale'
+
 import { Field, Meta } from 'tux'
 
 export interface Config {
@@ -221,14 +223,16 @@ export class ContentfulAdapter {
       throw new Error('Manager api not defined, please log in get a scheme.')
     }
 
-    return this.managementApi.getEntry(model.sys.id)
+    const entry = await this.managementApi.getEntry(model.sys.id)
+    return extractLocale(entry)
   }
 
-  loadAsset(model: any) {
+  async loadAsset(model: any) {
     if (!this.managementApi) {
       throw new Error('Manager api not defined, please log in get a scheme.')
     }
-    return this.managementApi.getAsset(model.sys.id)
+    const asset = await this.managementApi.getAsset(model.sys.id)
+    return extractLocale(asset)
   }
 
   async currentUser() {

--- a/packages/tux-adapter-contentful/src/adapter.ts
+++ b/packages/tux-adapter-contentful/src/adapter.ts
@@ -2,7 +2,7 @@ import QueryApi from './query-api'
 import ManagementApi from './management-api'
 import generateEditorSchema from './editors'
 
-import { extractLocale } from './locale'
+import { extractLocale, injectLocale } from './locale'
 
 import { Field, Meta } from 'tux'
 
@@ -145,7 +145,8 @@ export class ContentfulAdapter {
       throw new Error('Manager api not defined, please log in to save.')
     }
 
-    await this.managementApi.saveEntry(model)
+    const modelWithLocale = injectLocale(model)
+    await this.managementApi.saveEntry(modelWithLocale)
     this.triggerChange()
   }
 

--- a/packages/tux-adapter-contentful/src/locale.ts
+++ b/packages/tux-adapter-contentful/src/locale.ts
@@ -11,7 +11,6 @@ export function extractLocale(model: any) {
 export function injectLocale(model: any) {
   for (const fieldName of Object.keys(model.fields)) {
     const fieldValue = Object.assign(model.fields[fieldName])
-    console.log(fieldValue)
     model.fields[fieldName] = {
       [CURRENT_LOCALE]: fieldValue
     }

--- a/packages/tux-adapter-contentful/src/locale.ts
+++ b/packages/tux-adapter-contentful/src/locale.ts
@@ -1,0 +1,9 @@
+
+
+export function extractLocale(model: any) {
+  for (const fieldName of Object.keys(model.fields)) {
+    const fieldValue = model.fields[fieldName]['en-US']
+    model.fields[fieldName] = fieldValue
+  }
+  return model
+}

--- a/packages/tux-adapter-contentful/src/locale.ts
+++ b/packages/tux-adapter-contentful/src/locale.ts
@@ -1,9 +1,24 @@
-
+const CURRENT_LOCALE = 'en-US'
 
 export function extractLocale(model: any) {
   for (const fieldName of Object.keys(model.fields)) {
-    const fieldValue = model.fields[fieldName]['en-US']
+    const fieldValue = model.fields[fieldName][CURRENT_LOCALE]
     model.fields[fieldName] = fieldValue
   }
   return model
+}
+
+export function injectLocale(model: any) {
+  for (const fieldName of Object.keys(model.fields)) {
+    const fieldValue = Object.assign(model.fields[fieldName])
+    console.log(fieldValue)
+    model.fields[fieldName] = {
+      [CURRENT_LOCALE]: fieldValue
+    }
+  }
+  return model
+}
+
+function _copy(target: Object) {
+  return JSON.parse(JSON.stringify(target))
 }

--- a/packages/tux-adapter-contentful/src/locale.ts
+++ b/packages/tux-adapter-contentful/src/locale.ts
@@ -17,7 +17,3 @@ export function injectLocale(model: any) {
   }
   return model
 }
-
-function _copy(target: Object) {
-  return JSON.parse(JSON.stringify(target))
-}

--- a/packages/tux-example-site/src/components/SellPoints/index.js
+++ b/packages/tux-example-site/src/components/SellPoints/index.js
@@ -3,7 +3,10 @@ import { Editable } from 'tux'
 
 import './styles.css'
 
-const SellPoints = ({ sellPoints }) => (
+const SellPoints = ({ sellPoints }) => {
+  console.log(sellPoints)
+
+  return (
   <div className="SellPoints">
     {sellPoints && sellPoints.slice(0, 3).map((point, index) => (
       <Editable key={index} model={point} className="SellPoint">
@@ -15,6 +18,6 @@ const SellPoints = ({ sellPoints }) => (
       </Editable>
     ))}
   </div>
-)
+)}
 
 export default SellPoints

--- a/packages/tux-example-site/src/components/SellPoints/index.js
+++ b/packages/tux-example-site/src/components/SellPoints/index.js
@@ -3,10 +3,7 @@ import { Editable } from 'tux'
 
 import './styles.css'
 
-const SellPoints = ({ sellPoints }) => {
-  console.log(sellPoints)
-
-  return (
+const SellPoints = ({ sellPoints }) => (
   <div className="SellPoints">
     {sellPoints && sellPoints.slice(0, 3).map((point, index) => (
       <Editable key={index} model={point} className="SellPoint">
@@ -18,6 +15,6 @@ const SellPoints = ({ sellPoints }) => {
       </Editable>
     ))}
   </div>
-)}
+)
 
 export default SellPoints

--- a/packages/tux/src/components/Editable/EditableInline.tsx
+++ b/packages/tux/src/components/Editable/EditableInline.tsx
@@ -16,7 +16,6 @@ function setField<T>(model: any, field: FieldRef, editorState: T) {
   }
 
   let localized = field.slice()
-  localized.splice(2, 0, 'en-US')
 
   localized.reduce((object, key, index) => {
     if (index === localized.length - 1) {

--- a/packages/tux/src/components/TuxModal/TuxModal.tsx
+++ b/packages/tux/src/components/TuxModal/TuxModal.tsx
@@ -65,8 +65,7 @@ class TuxModal extends React.Component<any, State> {
     const { fullModel } = this.state
 
     const InputComponent = field.component
-    const fullModelField = fullModel.fields[field.field]
-    const value = fullModelField && fullModelField
+    const value = fullModel.fields[field.field]
 
     return InputComponent && (
       <div key={field.field}>

--- a/packages/tux/src/components/TuxModal/TuxModal.tsx
+++ b/packages/tux/src/components/TuxModal/TuxModal.tsx
@@ -44,10 +44,7 @@ class TuxModal extends React.Component<any, State> {
 
   onChange(value: any, type: string) {
     const { fullModel } = this.state
-    if (!fullModel.fields[type]) {
-      fullModel.fields[type] = {}
-    }
-    fullModel.fields[type]['en-US'] = value
+    fullModel.fields[type] = value
 
     this.setState({fullModel})
   }
@@ -69,7 +66,7 @@ class TuxModal extends React.Component<any, State> {
 
     const InputComponent = field.component
     const fullModelField = fullModel.fields[field.field]
-    const value = fullModelField && fullModelField['en-US']
+    const value = fullModelField && fullModelField
 
     return InputComponent && (
       <div key={field.field}>

--- a/packages/tux/src/components/fields/ImageField.tsx
+++ b/packages/tux/src/components/fields/ImageField.tsx
@@ -100,7 +100,6 @@ class ImageField extends React.Component<ImageFieldProps, any> {
     const asset = await this.context.tux.adapter.createAssetFromUrl(
       imageUrl,
       'test-image.jpeg',
-      'en-US',
       'Test Image'
     )
 

--- a/packages/tux/src/components/fields/ImageField.tsx
+++ b/packages/tux/src/components/fields/ImageField.tsx
@@ -125,8 +125,8 @@ class ImageField extends React.Component<ImageFieldProps, any> {
     const { imageUrl, fullModel, isLoadingImage } = this.state
 
     if (fullModel) {
-      const title = fullModel.fields.title['en-US']
-      const url = fullModel.fields.file['en-US'].url
+      const title = fullModel.fields.title
+      const url = fullModel.fields.file.url
       return (
           <div className="ImageField">
             <label className="InputLabel">{label}</label>


### PR DESCRIPTION
Part of [this refactoring initiative](https://github.com/aranja/tux-next/issues/54).

In the contentful adapter, let's make `load` and `save` unwrap the locale object *for now*. So `adapter.load(model) `returns a full model that's structurally similar to `model`, with `fullModel.fields.title` instead of `fullModel.fields.title['en-US']`. And `adapter.save(fullModel)` adds these locale objects back before saving.

What I have not implemented:
> Also, be careful not to "lose" other locale data when saving. (so store the actual full model and merge current locale changes into it).

~Will this be an issue?~ Yes, for when you have many locales and are only sending one when saving.