### PR TITLE
Explicit core-js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "@types/react-day-picker": "^1.2.37",
-    "babel-polyfill": "^6.23.0",
+    "babel-polyfill": "6.23.0",
+    "core-js": "2.4.1",
     "moment": "^2.17.1",
     "react": "^15.4.2",
     "react-day-picker": "^5.1.1",


### PR DESCRIPTION
Since it's used by both babel-polyfill and react. Our webpack transforms
depend on the version used by babel-polyfill.