### PR TITLE
Implement property accessors in tux

### DIFF
--- a/packages/tux-adapter-contentful/src/adapter.ts
+++ b/packages/tux-adapter-contentful/src/adapter.ts
@@ -179,6 +179,23 @@ export class ContentfulAdapter {
     return null
   }
 
+  formatAssetForLinking(asset: any) {
+    return {
+      sys: {
+        id: asset.sys.id,
+        linkType: 'Asset',
+        type: 'Link',
+      }
+    }
+  }
+
+  getIdOfEntity(entity: any) {
+    if (!entity.sys) {
+      return null
+    }
+    return entity.sys.id
+  }
+
   async createAssetFromUrl(url: string, fileName: string, title: string) {
     const assetBody = {
       fields: {

--- a/packages/tux-adapter-contentful/src/editors.ts
+++ b/packages/tux-adapter-contentful/src/editors.ts
@@ -25,7 +25,7 @@ export default function generateEditorSchema(typeMeta: any) {
 function _transformTypeMetaFieldToEditorField(typeMetaField: any) {
   const props = _getPropsForType(typeMetaField)
   return {
-    field: typeMetaField.id,
+    field: `fields.${typeMetaField.id}`,
     label: typeMetaField.name,
     component: widgetIdToEditor[typeMetaField.control.widgetId],
     props,

--- a/packages/tux/src/components/Editable/EditableInline.tsx
+++ b/packages/tux/src/components/Editable/EditableInline.tsx
@@ -1,29 +1,6 @@
 import React from 'react'
 import { MegadraftEditor, editorStateFromRaw, editorStateToJSON, EditorState } from 'megadraft'
-
-type FieldRef = string | string[]
-
-function getField<T>(model: any, field: FieldRef): T {
-  if (typeof field === 'string')
-    return getField<T>(model, field.split('.'))
-  return field.reduce((object, key) => object[key], model)
-}
-
-function setField<T>(model: any, field: FieldRef, editorState: T) {
-  if (typeof field === 'string') {
-    setField(model, field.split('.'), editorState)
-    return
-  }
-
-  let localized = field.slice()
-
-  localized.reduce((object, key, index) => {
-    if (index === localized.length - 1) {
-      object[key] = JSON.parse(editorStateToJSON(editorState))
-    }
-    return object[key]
-  }, model)
-}
+import { get, set } from '../../utils/accessors'
 
 export interface EditableInlineProps {
   model: any,
@@ -50,9 +27,12 @@ class EditableInline extends React.Component<EditableInlineProps, EditableInline
     super(props)
 
     const { model, field } = props
-    const content = getField(model, field)
-    this.state = {
-      editorState: editorStateFromRaw(content)
+    const content = get(model, field)
+
+    if (content) {
+      this.state = {
+        editorState: editorStateFromRaw(content)
+      }
     }
 
     this.saveChanges = this.saveChanges.bind(this)
@@ -63,7 +43,8 @@ class EditableInline extends React.Component<EditableInlineProps, EditableInline
     const { editorState } = this.state
 
     let fullModel = await this.context.tux.adapter.load(model)
-    setField(fullModel, field, editorState)
+    const editorStateObj = JSON.parse(editorStateToJSON(editorState))
+    set(fullModel, field, editorStateObj)
 
     this.context.tux.adapter.save(fullModel)
   }
@@ -84,16 +65,12 @@ class EditableInline extends React.Component<EditableInlineProps, EditableInline
     const { children, field, model, onChange } = this.props
     const isEditing = this.context.tux && this.context.tux.isEditing
 
-    if (isEditing || true) {
-      return (
-        <MegadraftEditor
-          editorState={this.state.editorState}
-          onChange={this.onEditorChange.bind(this)}
-          sidebarRendererFn={this.getCustomSidebar}/>
-      )
-    }
-
-    return <div>{getField(model, field)}</div>
+    return (
+      <MegadraftEditor
+        editorState={this.state.editorState}
+        onChange={this.onEditorChange.bind(this)}
+        sidebarRendererFn={this.getCustomSidebar}/>
+    )
   }
 }
 

--- a/packages/tux/src/components/TuxModal/TuxModal.tsx
+++ b/packages/tux/src/components/TuxModal/TuxModal.tsx
@@ -5,6 +5,7 @@ import { fade } from '../../utils/color'
 import moment from 'moment'
 import TuxSpinner from '../Spinner/Spinner'
 
+import { get } from '../../utils/accessors'
 import { getEditorSchema, Field } from '../../services/editor'
 
 export interface State {
@@ -65,7 +66,7 @@ class TuxModal extends React.Component<any, State> {
     const { fullModel } = this.state
 
     const InputComponent = field.component
-    const value = fullModel.fields[field.field]
+    const value = get(fullModel, field.field)
 
     return InputComponent && (
       <div key={field.field}>

--- a/packages/tux/src/components/TuxModal/TuxModal.tsx
+++ b/packages/tux/src/components/TuxModal/TuxModal.tsx
@@ -5,7 +5,7 @@ import { fade } from '../../utils/color'
 import moment from 'moment'
 import TuxSpinner from '../Spinner/Spinner'
 
-import { get } from '../../utils/accessors'
+import { get, set } from '../../utils/accessors'
 import { getEditorSchema, Field } from '../../services/editor'
 
 export interface State {
@@ -45,9 +45,8 @@ class TuxModal extends React.Component<any, State> {
 
   onChange(value: any, type: string) {
     const { fullModel } = this.state
-    fullModel.fields[type] = value
-
-    this.setState({fullModel})
+    set(fullModel, type, value)
+    this.setState({ fullModel })
   }
 
   onCancel = () => {

--- a/packages/tux/src/components/fields/ImageField.tsx
+++ b/packages/tux/src/components/fields/ImageField.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import classNames from 'classnames'
+import { get } from '../../utils/accessors'
 
 import { tuxInputStyles } from '../../styles'
 import TextField from './TextField'
 import BrowseField from './BrowseField'
-
 
 export interface ImageFieldProps {
   field: string | Array<string>,
@@ -14,13 +14,7 @@ export interface ImageFieldProps {
   label: string,
   name: string,
   onChange: Function,
-  value: {
-    sys: {
-      id: string,
-      type: string,
-      linkType: string,
-    }
-  },
+  value: any,
 }
 
 
@@ -48,11 +42,14 @@ class ImageField extends React.Component<ImageFieldProps, any> {
   }
 
   async componentWillReceiveProps(props: ImageFieldProps) {
-    if (!props.value || !props.value.sys) {
+    if (!props.value) {
       return
     }
 
-    if (props.value.sys.id !== this.props.value.sys.id) {
+    const nextValueId = this.context.tux.adapter.getIdOfEntity(props.value)
+    const currentValueId = this.context.tux.adapter.getIdOfEntity(this.props.value)
+
+    if ((nextValueId !== currentValueId) && nextValueId !== null) {
       const fullModel = await this.context.tux.adapter.loadAsset(props.value)
 
       this.setState({
@@ -69,14 +66,9 @@ class ImageField extends React.Component<ImageFieldProps, any> {
     })
 
     const asset = await this.context.tux.adapter.createAssetFromFile(files[0], 'Some title')
+    const linkableAsset = this.context.tux.adapter.formatAssetForLinking(asset)
 
-    onChange({
-      sys: {
-        id: asset.sys.id,
-        linkType: 'Asset',
-        type: 'Link'
-      }
-    })
+    onChange(linkableAsset)
 
     this.setState({
       isLoadingImage: false,
@@ -89,43 +81,14 @@ class ImageField extends React.Component<ImageFieldProps, any> {
     })
   }
 
-  loadImageFromUrl = async() => {
-    const { onChange } = this.props
-    const { imageUrl } = this.state
-
-    this.setState({
-      isLoadingImage: true,
-    })
-
-    const asset = await this.context.tux.adapter.createAssetFromUrl(
-      imageUrl,
-      'test-image.jpeg',
-      'Test Image'
-    )
-
-    onChange({
-      sys: {
-        id: asset.sys.id,
-        linkType: 'Asset',
-        type: 'Link'
-      }
-    }, {
-      type: this.props.id
-    })
-
-    this.setState({
-      isLoadingImage: false,
-      imageUrl: '',
-    })
-  }
-
   render() {
     const { value, id, onChange, label } = this.props
     const { imageUrl, fullModel, isLoadingImage } = this.state
 
     if (fullModel) {
-      const title = fullModel.fields.title
-      const url = fullModel.fields.file.url
+      const title = get(fullModel, 'fields.title')
+      const url = get(fullModel, 'fields.file.url')
+
       return (
           <div className="ImageField">
             <label className="InputLabel">{label}</label>

--- a/packages/tux/src/services/editor.spec.ts
+++ b/packages/tux/src/services/editor.spec.ts
@@ -5,7 +5,7 @@ describe('editor service', () => {
   it('can register editable and receive editor schema', () => {
     const modelName = 'article'
     const fields = [
-      { field: 'testField', label: 'testLabel' }
+      { field: 'fields.testField', label: 'testLabel' }
     ]
 
     registerEditable(modelName, fields)
@@ -20,13 +20,13 @@ describe('editor service', () => {
   it('can register fields and then filter them with a procedure', () => {
     const modelName = 'post'
     const fields = [
-      { field: 'firstName' },
-      { field: 'lastName' },
-      { field: '_fieldThatShouldNotBeEditable' },
+      { field: 'fields.firstName' },
+      { field: 'fields.lastName' },
+      { field: 'fields._fieldThatShouldNotBeEditable' },
     ]
 
     registerEditable(modelName, (schema: Map<string, Field>) => {
-      schema.delete('_fieldThatShouldNotBeEditable')
+      schema.delete('fields._fieldThatShouldNotBeEditable')
     })
 
     const schema = getEditorSchema({

--- a/packages/tux/src/utils/accessors.spec.ts
+++ b/packages/tux/src/utils/accessors.spec.ts
@@ -1,0 +1,13 @@
+import { get } from './accessors'
+
+describe('the get accessor', () => {
+  it('can fetch one level deep', () => {
+    const expected = 'nice'
+    const source = {
+      first: expected,
+    }
+
+    const result = get(source, 'first')
+    expect(result).toEqual(expected)
+  })
+})

--- a/packages/tux/src/utils/accessors.spec.ts
+++ b/packages/tux/src/utils/accessors.spec.ts
@@ -10,4 +10,35 @@ describe('the get accessor', () => {
     const result = get(source, 'first')
     expect(result).toEqual(expected)
   })
+
+  it('can fetch two levels deep', () => {
+    const key = 'first.second'
+    const expected = 'nice'
+    const source = {
+      first: {
+        second: expected,
+      },
+      [key]: 'not nice',
+    }
+
+    const result = get(source, key)
+    expect(result).toEqual(expected)
+  })
+
+  it('can fetch four levels deep', () => {
+    const key = 'first.second.third.fourth'
+    const expected = 'nice'
+    const source = {
+      first: {
+        second: {
+          third: {
+            fourth: expected
+          }
+        }
+      }
+    }
+
+    const result = get(source, key)
+    expect(result).toEqual(expected)
+  })
 })

--- a/packages/tux/src/utils/accessors.spec.ts
+++ b/packages/tux/src/utils/accessors.spec.ts
@@ -50,4 +50,17 @@ describe('the get accessor', () => {
     const result = get(source, key)
     expect(result).toEqual(expected)
   })
+
+  it('can handle when key is array', () => {
+    const expected = 'nice'
+    const key = ['first', 'second']
+    const source = {
+      first: {
+        second: expected,
+      },
+    }
+
+    const result = get(source, key)
+    expect(result).toEqual(expected)
+  })
 })

--- a/packages/tux/src/utils/accessors.spec.ts
+++ b/packages/tux/src/utils/accessors.spec.ts
@@ -89,4 +89,22 @@ describe('the set accessor', () => {
     const result = get(source, key)
     expect(result).toEqual(expected)
   })
+
+  it('can create path to key if it does not exist', () => {
+    const expected = 'nice'
+    const key = 'first.second.third'
+    const source = {}
+    set(source, key, expected)
+    const result = get(source, key)
+    expect(result).toEqual(expected)
+  })
+
+  it('can create first level key', () => {
+    const expected = 'nice'
+    const key = 'first'
+    const source = {}
+    set(source, key, expected)
+    const result = get(source, key)
+    expect(result).toEqual(expected)
+  })
 })

--- a/packages/tux/src/utils/accessors.spec.ts
+++ b/packages/tux/src/utils/accessors.spec.ts
@@ -1,4 +1,4 @@
-import { get } from './accessors'
+import { get, set } from './accessors'
 
 describe('the get accessor', () => {
   it('can fetch one level deep', () => {
@@ -60,6 +60,32 @@ describe('the get accessor', () => {
       },
     }
 
+    const result = get(source, key)
+    expect(result).toEqual(expected)
+  })
+})
+
+describe('the set accessor', () => {
+  it('can set a value at first level', () => {
+    const expected = 'nice'
+    const key = 'first'
+    const source = {}
+
+    set(source, key, expected)
+    const result = get(source, key)
+    expect(result).toEqual(expected)
+  })
+
+  it('can set a value at third level', () => {
+    const expected = 'nice'
+    const key = 'first.second.third'
+    const source = {
+      first: {
+        second: {}
+      }
+    }
+
+    set(source, key, expected)
     const result = get(source, key)
     expect(result).toEqual(expected)
   })

--- a/packages/tux/src/utils/accessors.spec.ts
+++ b/packages/tux/src/utils/accessors.spec.ts
@@ -41,4 +41,13 @@ describe('the get accessor', () => {
     const result = get(source, key)
     expect(result).toEqual(expected)
   })
+
+  it('returns null if key does not exist', () => {
+    const key = 'first.second.third'
+    const expected = null
+    const source = {}
+
+    const result = get(source, key)
+    expect(result).toEqual(expected)
+  })
 })

--- a/packages/tux/src/utils/accessors.ts
+++ b/packages/tux/src/utils/accessors.ts
@@ -2,16 +2,23 @@
  * Gets the value of a property on an object.
  *
  * @param {Object} obj The value to be clamped
- * @param {String} keyName The lower boundary of the output range
+ * @param {String} key The lower boundary of the output range
  * @returns {Object} the property value or 'null'.
  */
-export function get(obj: any, keyName: string): any {
-  if (keyName.length === 0 || !obj) {
+export function get(obj: any, key: string | string[]): any {
+  if (key.length === 0 || !obj) {
     return obj ? obj : null
   }
 
-  const parts = keyName.split('.')
+  const parts = _splitKey(key)
   const nextLevel = obj[parts[0]]
   const restOfKey = parts.slice(1, parts.length).join('.')
   return get(nextLevel, restOfKey)
+}
+
+function _splitKey(key: string | string[]) {
+  if (key instanceof Array) {
+    return key
+  }
+  return key.split('.')
 }

--- a/packages/tux/src/utils/accessors.ts
+++ b/packages/tux/src/utils/accessors.ts
@@ -20,7 +20,7 @@ export function set(obj: any, key: string | string[], value: any): void {
   const parts = _splitKey(key)
   if (parts.length === 1) {
     obj[parts[0]] = value
-  } else {
+  } else if (parts.length > 1) {
     const lastKeyPartIndex = parts.length - 1
     const parent = get(obj, parts.slice(0, lastKeyPartIndex))
     const lastKeyPart = parts[lastKeyPartIndex]

--- a/packages/tux/src/utils/accessors.ts
+++ b/packages/tux/src/utils/accessors.ts
@@ -6,8 +6,8 @@
  * @returns {Object} the property value or 'null'.
  */
 export function get(obj: any, keyName: string): any {
-  if (keyName.length === 0) {
-    return obj
+  if (keyName.length === 0 || !obj) {
+    return obj ? obj : null
   }
 
   const parts = keyName.split('.')

--- a/packages/tux/src/utils/accessors.ts
+++ b/packages/tux/src/utils/accessors.ts
@@ -1,0 +1,10 @@
+/**
+ * Gets the value of a property on an object.
+ *
+ * @param {Object} obj The value to be clamped
+ * @param {String} keyName The lower boundary of the output range
+ * @returns {Object} the property value or 'null'.
+ */
+export function get(obj: any, keyName: string) {
+  return obj[keyName]
+}

--- a/packages/tux/src/utils/accessors.ts
+++ b/packages/tux/src/utils/accessors.ts
@@ -12,7 +12,7 @@ export function get(obj: any, key: string | string[]): any {
 
   const parts = _splitKey(key)
   const nextLevel = obj[parts[0]]
-  const restOfKey = parts.slice(1, parts.length).join('.')
+  const restOfKey = parts.slice(1, parts.length)
   return get(nextLevel, restOfKey)
 }
 
@@ -25,14 +25,22 @@ export function get(obj: any, key: string | string[]): any {
  */
 export function set(obj: any, key: string | string[], value: any): void {
   const parts = _splitKey(key)
-  if (parts.length === 1) {
-    obj[parts[0]] = value
-  } else if (parts.length > 1) {
-    const lastKeyPartIndex = parts.length - 1
-    const parent = get(obj, parts.slice(0, lastKeyPartIndex))
-    const lastKeyPart = parts[lastKeyPartIndex]
-    parent[lastKeyPart] = value
+  if (parts.length === 0) {
+    return
   }
+
+  const currentKey = parts[0]
+  if (parts.length === 1) {
+    obj[currentKey] = value
+    return
+  }
+
+  if (!obj[currentKey]) {
+    obj[currentKey] = {}
+  }
+
+  const restOfKey = parts.slice(1, parts.length)
+  set(obj[currentKey], restOfKey, value)
 }
 
 function _splitKey(key: string | string[]): string[] {

--- a/packages/tux/src/utils/accessors.ts
+++ b/packages/tux/src/utils/accessors.ts
@@ -16,7 +16,19 @@ export function get(obj: any, key: string | string[]): any {
   return get(nextLevel, restOfKey)
 }
 
-function _splitKey(key: string | string[]) {
+export function set(obj: any, key: string | string[], value: any): void {
+  const parts = _splitKey(key)
+  if (parts.length === 1) {
+    obj[parts[0]] = value
+  } else {
+    const lastKeyPartIndex = parts.length - 1
+    const parent = get(obj, parts.slice(0, lastKeyPartIndex))
+    const lastKeyPart = parts[lastKeyPartIndex]
+    parent[lastKeyPart] = value
+  }
+}
+
+function _splitKey(key: string | string[]): string[] {
   if (key instanceof Array) {
     return key
   }

--- a/packages/tux/src/utils/accessors.ts
+++ b/packages/tux/src/utils/accessors.ts
@@ -5,6 +5,13 @@
  * @param {String} keyName The lower boundary of the output range
  * @returns {Object} the property value or 'null'.
  */
-export function get(obj: any, keyName: string) {
-  return obj[keyName]
+export function get(obj: any, keyName: string): any {
+  if (keyName.length === 0) {
+    return obj
+  }
+
+  const parts = keyName.split('.')
+  const nextLevel = obj[parts[0]]
+  const restOfKey = parts.slice(1, parts.length).join('.')
+  return get(nextLevel, restOfKey)
 }

--- a/packages/tux/src/utils/accessors.ts
+++ b/packages/tux/src/utils/accessors.ts
@@ -1,8 +1,8 @@
 /**
  * Gets the value of a property on an object.
  *
- * @param {Object} obj The value to be clamped
- * @param {String} key The lower boundary of the output range
+ * @param {Object} obj The object to get from
+ * @param {String} key The key, can also be an array of strings
  * @returns {Object} the property value or 'null'.
  */
 export function get(obj: any, key: string | string[]): any {
@@ -16,6 +16,13 @@ export function get(obj: any, key: string | string[]): any {
   return get(nextLevel, restOfKey)
 }
 
+/**
+ * Sets the value of a property on an object.
+ *
+ * @param {Object} obj The object to change
+ * @param {String} key The key, can also be an array of strings
+ * @param {Object} value The value to place in the object
+ */
 export function set(obj: any, key: string | string[], value: any): void {
   const parts = _splitKey(key)
   if (parts.length === 1) {


### PR DESCRIPTION
#62 TuxModal should not know that there's a `.fields` parent object or a `en-US` field structure.

`type` now supports 'fields.title' and ['fields', 'title'] like the inline editor. Contentful schemas now refer to `fields.<fieldname>` instead of `<fieldname>.`