### PR TITLE
Display editable clues

### DIFF
--- a/packages/tux-example-site/src/components/Newsletter/index.js
+++ b/packages/tux-example-site/src/components/Newsletter/index.js
@@ -1,15 +1,15 @@
 import React from 'react'
+import { Editable } from 'tux'
 import './styles.css'
 
-const Newsletter = ({}) => (
+const Newsletter = ({ model }) => (
   <div className="Newsletter">
     <div className="Newsletter-register">
       <input type="text" className="Newsletter-registerInput" placeholder="Are you sure?" />
       <button className="Newsletter-registerButton">Sign up</button>
     </div>
     <div className="Newsletter-disclaimer">
-      <p>We send out cat facts 8 times a week. At least.</p>
-      <p>Unregister at any time by adopting a cat.</p>
+      <Editable model={model} field="fields.content.newsletterDisclaimer" />
     </div>
     <div className="Newsletter-social">
       <p className="Newsletter-socialIcon"><span className="icon icon-twitter_circle"></span></p>

--- a/packages/tux-example-site/src/components/Pricetable/index.js
+++ b/packages/tux-example-site/src/components/Pricetable/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Editable } from 'tux'
 import './styles.css'
 
 const Pricetable = ({ pricetableItems }) => (
@@ -8,18 +9,18 @@ const Pricetable = ({ pricetableItems }) => (
       const price = !isFree ? `$${item.fields.planPrice}` : 'free'
 
       return (
-        <div key={item.fields.planName} className="Pricetable-plan">
+        <Editable key={item.fields.planName} model={item} className="Pricetable-plan">
           <div>
             <h1 className="Pricetable-planHeading">{item.fields.planName}</h1>
             <div className="Pricetable-planPrice">{price}</div>
             <dl className="Pricetable-planList">
-              {item.fields.planList && item.fields.planList.split(', ').map((listItem) => (
+              {item.fields.planListTags && item.fields.planListTags.map((listItem) => (
                 <dt key={listItem} className="Pricetable-planListItem">{listItem}</dt>
               ))}
             </dl>
           </div>
           <a href="/" className="Pricetable-button">{isFree ? 'Get started' : 'Purchase'}</a>
-        </div>
+        </Editable>
       )
     })}
   </div>

--- a/packages/tux-example-site/src/routes/About.js
+++ b/packages/tux-example-site/src/routes/About.js
@@ -12,7 +12,6 @@ import SocialPlug from '../components/SocialPlug'
 
 import ProductBannerImage from '../ProductBannerImage.png'
 
-
 const About = ({ pages, sellPoints, gallery, testimonial, pricetable, articles }) => {
   const page = pages.items[0]
 
@@ -23,8 +22,8 @@ const About = ({ pages, sellPoints, gallery, testimonial, pricetable, articles }
       />
       <Menu />
       <ProductBanner image={ProductBannerImage}>
-        <div className="ProductBanner-heading"><Editable model={page} field="fields.content.title" /></div>
-        <div className="ProductBanner-text"><Editable model={page} field="fields.content.subtitle" /></div>
+        <div className="ProductBanner-heading"><Editable model={page} field="fields.content.title2" /></div>
+        <div className="ProductBanner-text"><Editable model={page} field="fields.content.subtitle2" /></div>
       </ProductBanner>
       <Section>
         <H1>Who is using Tux</H1>

--- a/packages/tux-example-site/src/routes/About.js
+++ b/packages/tux-example-site/src/routes/About.js
@@ -37,8 +37,8 @@ const About = ({ pages, sellPoints, gallery, testimonial, pricetable, articles }
         <Articles articles={articles} />
       </Section>
       <Section>
-        <H1>Get our Product for the Best Price</H1>
-        <H2>Contact us for Enterprise plans</H2>
+        <H1><Editable model={page} field="fields.content.pricetableTitle" /></H1>
+        <H2><Editable model={page} field="fields.content.pricetableSubtitle" /></H2>
         <Pricetable pricetableItems={pricetable.items} />
       </Section>
     </div>

--- a/packages/tux-example-site/src/routes/Home.js
+++ b/packages/tux-example-site/src/routes/Home.js
@@ -40,17 +40,17 @@ const Home = ({ pages, sellPoints, testimonial, carousel }) => {
         <Testimonial testimonial={testimonial.items}/>
       </Section>
       <Section backgroundColor="#F5F7FA">
-        <H1>What People Say About Tux</H1>
-        <H2>Totally random and unbiased selection of people</H2>
+        <H1><Editable model={page} field="fields.content.twitterFeedTitle" /></H1>
+        <H2><Editable model={page} field="fields.content.twitterFeedSubtitle" /></H2>
         <TwitterFeed />
         <SocialPlug>
           Are you using Tux? <strong>Let us know on Twitter</strong>
         </SocialPlug>
       </Section>
       <Section>
-        <H1>Sign up for our newsletter, you won't regret it *</H1>
-        <H2>* Unless you don't like cat facts.</H2>
-        <Newsletter />
+        <H1><Editable model={page} field="fields.content.newsletterTitle" /></H1>
+        <H2><Editable model={page} field="fields.content.newsletterSubtitle" /></H2>
+        <Newsletter model={page} />
       </Section>
     </div>
   )

--- a/packages/tux/src/components/AlertBar/index.tsx
+++ b/packages/tux/src/components/AlertBar/index.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import classNames from 'classnames'
+import { tuxColors } from '../../styles'
+
+const AlertBar = ({ isActive }) => (
+  <div className={classNames('AlertBar', isActive && 'is-active')}>
+    <p>You are in edit mode. Any changes you make will be published.</p>
+    <style jsx>{`
+      .AlertBar {
+        background: ${tuxColors.colorPink};
+        color: #FFF;
+        display: none;
+        justify-content: center;
+        padding: 5px;
+        position: fixed;
+        text-align: center;
+        top: 0;
+        width: 100%;
+        z-index: 50;
+      }
+      .AlertBar.is-active {
+        display: flex;
+      }
+      `}</style>
+  </div>
+)
+
+export default AlertBar

--- a/packages/tux/src/components/AlertBar/index.tsx
+++ b/packages/tux/src/components/AlertBar/index.tsx
@@ -2,14 +2,14 @@ import React from 'react'
 import classNames from 'classnames'
 import { tuxColors } from '../../styles'
 
-const AlertBar = ({ isActive }) => (
-  <div className={classNames('AlertBar', isActive && 'is-active')}>
+const AlertBar = () => (
+  <div className="AlertBar">
     <p>You are in edit mode. Any changes you make will be published.</p>
     <style jsx>{`
       .AlertBar {
         background: ${tuxColors.colorPink};
         color: #FFF;
-        display: none;
+        display: flex;
         justify-content: center;
         padding: 5px;
         position: fixed;
@@ -18,10 +18,7 @@ const AlertBar = ({ isActive }) => (
         width: 100%;
         z-index: 50;
       }
-      .AlertBar.is-active {
-        display: flex;
-      }
-      `}</style>
+    `}</style>
   </div>
 )
 

--- a/packages/tux/src/components/Editable/Editable.tsx
+++ b/packages/tux/src/components/Editable/Editable.tsx
@@ -33,7 +33,7 @@ class Editable extends React.Component<EditableProps, any> {
   render() {
     const { children, field, model, onChange, className } = this.props
     const { isLoggedIn } = this.state
-    const isEditing = this.context.tux && this.context.tux.isEditing
+    const isEditing = isLoggedIn && this.context.tux && this.context.tux.isEditing
     if (field) {
       return <EditableInline model={model} field={field} isLoggedIn={isLoggedIn}/>
     }

--- a/packages/tux/src/components/Editable/Editable.tsx
+++ b/packages/tux/src/components/Editable/Editable.tsx
@@ -8,7 +8,7 @@ export interface EditableProps {
   onChange: Function,
   children: any,
   className: string,
-  shouldDisplayClues: boolean,
+  isLoggedIn: boolean,
 }
 
 class Editable extends React.Component<EditableProps, any> {
@@ -17,7 +17,7 @@ class Editable extends React.Component<EditableProps, any> {
   }
 
   state = {
-    shouldDisplayClues: false,
+    isLoggedIn: false,
   }
 
   async componentDidMount() {
@@ -25,17 +25,17 @@ class Editable extends React.Component<EditableProps, any> {
 
     if (user) {
       this.setState({
-        shouldDisplayClues: true,
+        isLoggedIn: true,
       })
     }
   }
 
   render() {
     const { children, field, model, onChange, className } = this.props
-    const { shouldDisplayClues } = this.state
+    const { isLoggedIn } = this.state
     const isEditing = this.context.tux && this.context.tux.isEditing
     if (field) {
-      return <EditableInline model={model} field={field} shouldDisplayClues={shouldDisplayClues}/>
+      return <EditableInline model={model} field={field} isLoggedIn={isLoggedIn}/>
     }
 
     return (
@@ -43,7 +43,7 @@ class Editable extends React.Component<EditableProps, any> {
       className={className}
       model={model}
       onChange={onChange}
-      shouldDisplayClues={shouldDisplayClues}
+      isLoggedIn={isLoggedIn}
       >
         {children}
       </EditableModal>

--- a/packages/tux/src/components/Editable/Editable.tsx
+++ b/packages/tux/src/components/Editable/Editable.tsx
@@ -8,6 +8,7 @@ export interface EditableProps {
   onChange: Function,
   children: any,
   className: string,
+  shouldDisplayClues: boolean,
 }
 
 class Editable extends React.Component<EditableProps, any> {
@@ -15,16 +16,35 @@ class Editable extends React.Component<EditableProps, any> {
     tux: React.PropTypes.object,
   }
 
+  state = {
+    shouldDisplayClues: false,
+  }
+
+  async componentDidMount() {
+    const user = await this.context.tux.adapter.currentUser()
+
+    if (user) {
+      this.setState({
+        shouldDisplayClues: true,
+      })
+    }
+  }
+
   render() {
     const { children, field, model, onChange, className } = this.props
+    const { shouldDisplayClues } = this.state
     const isEditing = this.context.tux && this.context.tux.isEditing
-
     if (field) {
-      return <EditableInline model={model} field={field} />
+      return <EditableInline model={model} field={field} shouldDisplayClues={shouldDisplayClues}/>
     }
 
     return (
-      <EditableModal className={className} model={model} onChange={onChange}>
+      <EditableModal
+      className={className}
+      model={model}
+      onChange={onChange}
+      shouldDisplayClues={shouldDisplayClues}
+      >
         {children}
       </EditableModal>
     )

--- a/packages/tux/src/components/Editable/EditableInline.tsx
+++ b/packages/tux/src/components/Editable/EditableInline.tsx
@@ -76,7 +76,6 @@ class EditableInline extends React.Component<EditableInlineProps, EditableInline
         <style jsx>{`
           .display-editable-clue {
             animation: editableClue 1s;
-            animation-repeat-count: 3;
           }
           @keyframes editableClue {
             from {

--- a/packages/tux/src/components/Editable/EditableInline.tsx
+++ b/packages/tux/src/components/Editable/EditableInline.tsx
@@ -66,14 +66,27 @@ class EditableInline extends React.Component<EditableInlineProps, EditableInline
   render() {
     const { children, field, model, onChange, isLoggedIn } = this.props
     const isEditing = this.context.tux && this.context.tux.isEditing
+    const classes = classNames(
+      'EditableInline',
+      isEditing && 'is-editing',
+    )
 
     return (
-      <MegadraftEditor
-        readOnly={!isEditing}
-        editorState={this.state.editorState}
-        onChange={this.onEditorChange.bind(this)}
-        sidebarRendererFn={this.getCustomSidebar}
-      />
+      <div className={classes}>
+        <MegadraftEditor
+          readOnly={!isEditing}
+          editorState={this.state.editorState}
+          onChange={this.onEditorChange.bind(this)}
+          sidebarRendererFn={this.getCustomSidebar}
+        />
+        <style jsx>{`
+          .EditableInline.is-editing:hover {
+            cursor: text;
+            outline: 1px dashed rgba(128, 128, 128, 0.7);
+          }
+        `}
+        </style>
+      </div>
     )
   }
 }

--- a/packages/tux/src/components/Editable/EditableInline.tsx
+++ b/packages/tux/src/components/Editable/EditableInline.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import classNames from 'classnames'
 import { MegadraftEditor, editorStateFromRaw, editorStateToJSON, EditorState } from 'megadraft'
 import { get, set } from '../../utils/accessors'
 
@@ -6,6 +7,7 @@ export interface EditableInlineProps {
   model: any,
   field: string | Array<string>,
   onChange?: () => void,
+  shouldDisplayClues: boolean,
 }
 
 export interface EditableInlineState {
@@ -62,14 +64,30 @@ class EditableInline extends React.Component<EditableInlineProps, EditableInline
   }
 
   render() {
-    const { children, field, model, onChange } = this.props
+    const { children, field, model, onChange, shouldDisplayClues } = this.props
     const isEditing = this.context.tux && this.context.tux.isEditing
 
     return (
-      <MegadraftEditor
+      <div className={classNames(shouldDisplayClues && 'display-editable-clue')}>
+        <MegadraftEditor
         editorState={this.state.editorState}
         onChange={this.onEditorChange.bind(this)}
         sidebarRendererFn={this.getCustomSidebar}/>
+        <style jsx>{`
+          .display-editable-clue {
+            animation: editableClue 1s;
+            animation-repeat-count: 3;
+          }
+          @keyframes editableClue {
+            from {
+              background: rgba(232, 0, 138, 0.2);
+            }
+            to {
+              background: rgba(232, 0, 138, 0);
+            }
+          }
+        `}</style>
+      </div>
     )
   }
 }

--- a/packages/tux/src/components/Editable/EditableInline.tsx
+++ b/packages/tux/src/components/Editable/EditableInline.tsx
@@ -68,27 +68,12 @@ class EditableInline extends React.Component<EditableInlineProps, EditableInline
     const isEditing = this.context.tux && this.context.tux.isEditing
 
     return (
-      <div className={classNames(isLoggedIn && 'display-editable-clue')}>
-        <MegadraftEditor
-          readOnly={!isEditing}
-          editorState={this.state.editorState}
-          onChange={this.onEditorChange.bind(this)}
-          sidebarRendererFn={this.getCustomSidebar}
-        />
-        <style jsx>{`
-          .display-editable-clue {
-            animation: editableClue 1s;
-          }
-          @keyframes editableClue {
-            from {
-              background: rgba(232, 0, 138, 0.2);
-            }
-            to {
-              background: rgba(232, 0, 138, 0);
-            }
-          }
-        `}</style>
-      </div>
+      <MegadraftEditor
+        readOnly={!isEditing}
+        editorState={this.state.editorState}
+        onChange={this.onEditorChange.bind(this)}
+        sidebarRendererFn={this.getCustomSidebar}
+      />
     )
   }
 }

--- a/packages/tux/src/components/Editable/EditableInline.tsx
+++ b/packages/tux/src/components/Editable/EditableInline.tsx
@@ -70,7 +70,7 @@ class EditableInline extends React.Component<EditableInlineProps, EditableInline
     return (
       <div className={classNames(isLoggedIn && 'display-editable-clue')}>
         <MegadraftEditor
-          readOnly={!isLoggedIn}
+          readOnly={!isEditing}
           editorState={this.state.editorState}
           onChange={this.onEditorChange.bind(this)}
           sidebarRendererFn={this.getCustomSidebar}

--- a/packages/tux/src/components/Editable/EditableInline.tsx
+++ b/packages/tux/src/components/Editable/EditableInline.tsx
@@ -7,7 +7,7 @@ export interface EditableInlineProps {
   model: any,
   field: string | Array<string>,
   onChange?: () => void,
-  shouldDisplayClues: boolean,
+  isLoggedIn: boolean,
 }
 
 export interface EditableInlineState {
@@ -64,15 +64,17 @@ class EditableInline extends React.Component<EditableInlineProps, EditableInline
   }
 
   render() {
-    const { children, field, model, onChange, shouldDisplayClues } = this.props
+    const { children, field, model, onChange, isLoggedIn } = this.props
     const isEditing = this.context.tux && this.context.tux.isEditing
 
     return (
-      <div className={classNames(shouldDisplayClues && 'display-editable-clue')}>
+      <div className={classNames(isLoggedIn && 'display-editable-clue')}>
         <MegadraftEditor
-        editorState={this.state.editorState}
-        onChange={this.onEditorChange.bind(this)}
-        sidebarRendererFn={this.getCustomSidebar}/>
+          readOnly={!isLoggedIn}
+          editorState={this.state.editorState}
+          onChange={this.onEditorChange.bind(this)}
+          sidebarRendererFn={this.getCustomSidebar}
+        />
         <style jsx>{`
           .display-editable-clue {
             animation: editableClue 1s;

--- a/packages/tux/src/components/Editable/EditableModal.tsx
+++ b/packages/tux/src/components/Editable/EditableModal.tsx
@@ -15,7 +15,7 @@ class EditableModal extends React.Component<EditableModalProps, any> {
   }
 
   async onEdit(): Promise<void> {
-    const { onChange, model, isLoggedIn } = this.props
+    const { onChange, model } = this.props
     const { tux } = this.context
     const isEditing = tux && tux.isEditing
     const didChange = await tux.editModel(model)

--- a/packages/tux/src/components/Editable/EditableModal.tsx
+++ b/packages/tux/src/components/Editable/EditableModal.tsx
@@ -6,6 +6,7 @@ export interface EditableModalProps {
   children?: any,
   onChange: Function,
   className: string,
+  shouldDisplayClues: boolean,
 }
 
 class EditableModal extends React.Component<EditableModalProps, any> {
@@ -24,9 +25,15 @@ class EditableModal extends React.Component<EditableModalProps, any> {
   }
 
   render() {
-    const { model, children, className } = this.props
-    const isEditing = this.context.tux && this.context.tux.isEditing
-    const classes = classNames(className, 'EditableModal', isEditing && 'is-editing')
+    const { model, children, className, shouldDisplayClues } = this.props
+    const isEditing = this.context.tux && this.context.tux.isEditing // todo: is this ever true?
+    const classes = classNames(
+      className,
+      'EditableModal',
+      isEditing && 'is-editing',
+      shouldDisplayClues && 'display-editable-clue'
+    )
+
     return (
       <div className={classes} onClick={() => this.onEdit()}>
         {children}
@@ -36,6 +43,18 @@ class EditableModal extends React.Component<EditableModalProps, any> {
           }
           .EditableModal.is-editing, .EditableModal.is-editing > * {
             outline: 1px solid aquamarine !important;
+          }
+          .display-editable-clue {
+            animation: editableClue 1s;
+            animation-repeat-count: 3;
+          }
+          @keyframes editableClue {
+            from {
+              background: rgba(232, 0, 138, 0.2);
+            }
+            to {
+              background: rgba(232, 0, 138, 0);
+            }
           }
         `}</style>
       </div>

--- a/packages/tux/src/components/Editable/EditableModal.tsx
+++ b/packages/tux/src/components/Editable/EditableModal.tsx
@@ -37,6 +37,13 @@ class EditableModal extends React.Component<EditableModalProps, any> {
     return (
       <div className={classes} onClick={() => {isEditing && this.onEdit()}}>
         {children}
+        <style jsx>{`
+          .EditableModal.is-editing:hover {
+            cursor: pointer;
+            outline: 1px dashed rgba(128, 128, 128, 0.7);
+          }
+        `}
+        </style>
       </div>
     )
   }

--- a/packages/tux/src/components/Editable/EditableModal.tsx
+++ b/packages/tux/src/components/Editable/EditableModal.tsx
@@ -46,7 +46,6 @@ class EditableModal extends React.Component<EditableModalProps, any> {
           }
           .display-editable-clue {
             animation: editableClue 1s;
-            animation-repeat-count: 3;
           }
           @keyframes editableClue {
             from {

--- a/packages/tux/src/components/Editable/EditableModal.tsx
+++ b/packages/tux/src/components/Editable/EditableModal.tsx
@@ -6,7 +6,6 @@ export interface EditableModalProps {
   children?: any,
   onChange: Function,
   className: string,
-  isLoggedIn: boolean,
 }
 
 class EditableModal extends React.Component<EditableModalProps, any> {
@@ -25,7 +24,7 @@ class EditableModal extends React.Component<EditableModalProps, any> {
   }
 
   render() {
-    const { model, children, className, isLoggedIn } = this.props
+    const { model, children, className } = this.props
     const isEditing = this.context.tux && this.context.tux.isEditing
 
     const classes = classNames(

--- a/packages/tux/src/components/Editable/EditableModal.tsx
+++ b/packages/tux/src/components/Editable/EditableModal.tsx
@@ -32,31 +32,11 @@ class EditableModal extends React.Component<EditableModalProps, any> {
       className,
       'EditableModal',
       isEditing && 'is-editing',
-      isLoggedIn && 'display-editable-clue'
     )
 
     return (
       <div className={classes} onClick={() => {isEditing && this.onEdit()}}>
         {children}
-        <style jsx>{`
-          .EditableModal.is-editing {
-            cursor: pointer;
-          }
-          .EditableModal.is-editing, .EditableModal.is-editing > * {
-            outline: 1px solid aquamarine !important;
-          }
-          .display-editable-clue {
-            animation: editableClue 1s;
-          }
-          @keyframes editableClue {
-            from {
-              background: rgba(232, 0, 138, 0.2);
-            }
-            to {
-              background: rgba(232, 0, 138, 0);
-            }
-          }
-        `}</style>
       </div>
     )
   }

--- a/packages/tux/src/components/Editable/EditableModal.tsx
+++ b/packages/tux/src/components/Editable/EditableModal.tsx
@@ -6,7 +6,7 @@ export interface EditableModalProps {
   children?: any,
   onChange: Function,
   className: string,
-  shouldDisplayClues: boolean,
+  isLoggedIn: boolean,
 }
 
 class EditableModal extends React.Component<EditableModalProps, any> {
@@ -15,7 +15,7 @@ class EditableModal extends React.Component<EditableModalProps, any> {
   }
 
   async onEdit(): Promise<void> {
-    const { onChange, model } = this.props
+    const { onChange, model, isLoggedIn } = this.props
     const { tux } = this.context
     const isEditing = tux && tux.isEditing
     const didChange = await tux.editModel(model)
@@ -25,17 +25,17 @@ class EditableModal extends React.Component<EditableModalProps, any> {
   }
 
   render() {
-    const { model, children, className, shouldDisplayClues } = this.props
+    const { model, children, className, isLoggedIn } = this.props
     const isEditing = this.context.tux && this.context.tux.isEditing // todo: is this ever true?
     const classes = classNames(
       className,
       'EditableModal',
       isEditing && 'is-editing',
-      shouldDisplayClues && 'display-editable-clue'
+      isLoggedIn && 'display-editable-clue'
     )
 
     return (
-      <div className={classes} onClick={() => this.onEdit()}>
+      <div className={classes} onClick={() => {isLoggedIn && this.onEdit()}}>
         {children}
         <style jsx>{`
           .EditableModal.is-editing {

--- a/packages/tux/src/components/Editable/EditableModal.tsx
+++ b/packages/tux/src/components/Editable/EditableModal.tsx
@@ -26,7 +26,8 @@ class EditableModal extends React.Component<EditableModalProps, any> {
 
   render() {
     const { model, children, className, isLoggedIn } = this.props
-    const isEditing = this.context.tux && this.context.tux.isEditing // todo: is this ever true?
+    const isEditing = this.context.tux && this.context.tux.isEditing
+
     const classes = classNames(
       className,
       'EditableModal',
@@ -35,7 +36,7 @@ class EditableModal extends React.Component<EditableModalProps, any> {
     )
 
     return (
-      <div className={classes} onClick={() => {isLoggedIn && this.onEdit()}}>
+      <div className={classes} onClick={() => {isEditing && this.onEdit()}}>
         {children}
         <style jsx>{`
           .EditableModal.is-editing {

--- a/packages/tux/src/components/TuxProvider/TuxProvider.tsx
+++ b/packages/tux/src/components/TuxProvider/TuxProvider.tsx
@@ -80,7 +80,9 @@ class TuxProvider extends Component<TuxProviderProps, any> {
     const { isEditing, sidebarIsActive, overlayIsActive } = this.state
     return (
       <div className="TuxProvider" style={{paddingTop: isEditing && 36}}>
-        <AlertBar isActive={isEditing} />
+        {isEditing && (
+          <AlertBar />
+        )}
         <TuxSidebar
           isEditing={isEditing}
           sidebarIsActive={sidebarIsActive}

--- a/packages/tux/src/components/TuxProvider/TuxProvider.tsx
+++ b/packages/tux/src/components/TuxProvider/TuxProvider.tsx
@@ -3,9 +3,12 @@ import classNames from 'classnames'
 import ModalContainer, { openModal } from '../TuxModalContainer'
 import TuxSidebar from '../TuxSidebar'
 import TuxModal from '../TuxModal'
+import AlertBar from '../AlertBar'
 
 export interface TuxProviderProps {
-  adapter: Object
+  adapter: {
+    currentUser: Function
+  }
 }
 
 class TuxProvider extends Component<TuxProviderProps, any> {
@@ -21,7 +24,9 @@ class TuxProvider extends Component<TuxProviderProps, any> {
     isEditing: false,
     overlayIsActive: false,
     sidebarIsActive: false,
+    isLoggedIn: false,
   }
+
 
   getChildContext() {
     return {
@@ -30,6 +35,16 @@ class TuxProvider extends Component<TuxProviderProps, any> {
         editModel: this.editModel,
         adapter: this.props.adapter,
       },
+    }
+  }
+
+  async componentDidMount() {
+    const user = await this.props.adapter.currentUser()
+
+    if (user) {
+      this.setState({
+        isLoggedIn: true,
+      })
     }
   }
 
@@ -51,18 +66,21 @@ class TuxProvider extends Component<TuxProviderProps, any> {
   }
 
   onClickEdit = () => {
-    const { isEditing } = this.state
+    // Todo set isEditing state in localStorage
+    const { isEditing, isLoggedIn } = this.state
 
-    this.setState({
-      isEditing: !isEditing
-    })
+    if (isLoggedIn) {
+      this.setState({
+        isEditing: !isEditing
+      })
+    }
   }
 
   render() {
     const { isEditing, sidebarIsActive, overlayIsActive } = this.state
-
     return (
-      <div className="TuxProvider">
+      <div className="TuxProvider" style={{paddingTop: isEditing && 36}}>
+        <AlertBar isActive={isEditing} />
         <TuxSidebar
           isEditing={isEditing}
           sidebarIsActive={sidebarIsActive}

--- a/packages/tux/src/components/TuxSidebar/TuxSidebar.tsx
+++ b/packages/tux/src/components/TuxSidebar/TuxSidebar.tsx
@@ -89,7 +89,7 @@ class TuxSidebar extends React.Component<any, State> {
             right: 0;
             height: 100%;
             min-height: 100vh;
-            z-index: 100;
+            z-index: 20;
             box-shadow: 7px 1px 10px ${fade(tuxColors.colorBlack, 0.2)};
             transform: translateX(100%);
             transition: transform 0.4s ease-out;
@@ -119,7 +119,7 @@ class TuxSidebar extends React.Component<any, State> {
             bottom: 135px;
             transform: rotateZ(-90deg);
             width: 100px;
-            z-index: 101;
+            z-index: 30;
           }
 
           /*Sneak peak on hover*/

--- a/packages/tux/src/components/TuxSidebar/TuxSidebar.tsx
+++ b/packages/tux/src/components/TuxSidebar/TuxSidebar.tsx
@@ -181,7 +181,7 @@ class TuxSidebar extends React.Component<any, State> {
           }
 
           .TuxSidebar-user {
-            bottom: 25px;
+            bottom: 50px;
             left: 0; right: 0;
             margin: auto;
             position: absolute;

--- a/packages/tux/src/components/fields/TagEditor.tsx
+++ b/packages/tux/src/components/fields/TagEditor.tsx
@@ -27,7 +27,6 @@ class TagEditor extends Component<TagEditorProps, any> {
     const prevTags: Array<string> = []
     const isArray = value instanceof Array
 
-
     if (value && isArray) {
       value.map((value) => {
         prevTags.push(value)
@@ -45,6 +44,23 @@ class TagEditor extends Component<TagEditorProps, any> {
 
     if (!this.isUnmounting) {
       onChange(newTags)
+    }
+  }
+
+  onItemDeleted = (tag) => {
+    const { onChange } = this.props
+
+    onChange(tag)
+  }
+
+  handleClickDelete = (item) => {
+    const { tags } = this.state
+    const newTags = tags
+    const tagPosition = newTags.indexOf(item.singleValue)
+
+    if (tagPosition > -1) {
+      newTags.splice(tagPosition, 1)
+      this.onItemDeleted(newTags)
     }
   }
 
@@ -80,10 +96,10 @@ class TagEditor extends Component<TagEditorProps, any> {
           onClick={this.handleOnKeyUp}
         />
         <div className="TagEditor-tags">
-          {value && value.map((singleValue) => (
+          {value instanceof Array && value.map((singleValue) => (
             <p key={singleValue} className="TagEditor-tag">
               {singleValue}
-              <span className="TagEditor-tagButton"></span>
+              <span className="TagEditor-tagButton" onClick={() => this.handleClickDelete({singleValue})}></span>
             </p>
           ))}
         </div>
@@ -104,7 +120,8 @@ class TagEditor extends Component<TagEditorProps, any> {
 
             .TagEditor-tags {
               display: flex;
-              margin: 10px 0;
+              flex-wrap: wrap;
+              margin: 10px -5px;
             }
 
             .TagEditor-tag {
@@ -114,10 +131,10 @@ class TagEditor extends Component<TagEditorProps, any> {
               color: ${tuxInputStyles.labelTextColor};
               font-size: 13px;
               padding: 4px 12px;
+              margin: 5px;
             }
 
             .TagEditor-tag:not(:last-child) {
-              margin-right: 10px;
             }
 
             .TagEditor-tagButton {

--- a/packages/tux/src/components/fields/TagEditor.tsx
+++ b/packages/tux/src/components/fields/TagEditor.tsx
@@ -137,9 +137,6 @@ class TagEditor extends Component<TagEditorProps, any> {
               margin: 5px;
             }
 
-            .TagEditor-tag:not(:last-child) {
-            }
-
             .TagEditor-tagButton {
               font-family: 'mfg_labs_iconsetregular';
               font-style: normal;

--- a/packages/tux/src/components/fields/TagEditor.tsx
+++ b/packages/tux/src/components/fields/TagEditor.tsx
@@ -99,7 +99,10 @@ class TagEditor extends Component<TagEditorProps, any> {
           {value instanceof Array && value.map((singleValue) => (
             <p key={singleValue} className="TagEditor-tag">
               {singleValue}
-              <span className="TagEditor-tagButton" onClick={() => this.handleClickDelete({singleValue})}></span>
+              <span
+                className="TagEditor-tagButton"
+                onClick={() => this.handleClickDelete({singleValue})}>
+              </span>
             </p>
           ))}
         </div>


### PR DESCRIPTION
Added AlertBar that displays when isEditing. Disabled editing capabilities when **not** in edit-mode. Disabled triggering edit mode when not logged in.

Display dotted outline on hover to indicate editability (cursor not visible in screenshot):

![image](https://cloud.githubusercontent.com/assets/8494120/24000077/21a7d0b2-0a52-11e7-8b6e-9e9dce4aabda.png)

![image](https://cloud.githubusercontent.com/assets/8494120/23999919/b06fa7ee-0a51-11e7-98e7-6a5be4ed9400.png)

![image](https://cloud.githubusercontent.com/assets/8494120/24000093/30c2be40-0a52-11e7-9fdc-e31bed24f39a.png)

