### PR TITLE
Implement new prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/react-day-picker": "^1.2.37",
     "core-js": "2.4.1",
     "moment": "^2.17.1",
+    "prop-types": "~15.5.8",
     "react": "15.4.2",
     "react-day-picker": "^5.1.1",
     "react-dom": "15.4.2",

--- a/packages/tux-example-site/src/components/HistoryLink/index.js
+++ b/packages/tux-example-site/src/components/HistoryLink/index.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react'
+import PropTypes from 'prop-types'
 import type { History } from 'utilities/typedefs'
 
 function isLeftClickEvent(event) {
@@ -95,7 +96,7 @@ class HistoryLink extends React.Component {
   }
 }
 HistoryLink.contextTypes = {
-  history: React.PropTypes.object.isRequired,
+  history: PropTypes.object.isRequired,
 }
 
 HistoryLink.defaultProps = {

--- a/packages/tux/src/components/Editable/Editable.tsx
+++ b/packages/tux/src/components/Editable/Editable.tsx
@@ -1,4 +1,5 @@
 import React, { ComponentClass, StatelessComponent } from 'react'
+import PropTypes from 'prop-types'
 import { EditableProps } from '../../interfaces'
 
 export interface State {
@@ -13,12 +14,12 @@ export function createEditable<OriginalProps>() {
   ): ComponentClass<EditableProps> {
     class Editable extends React.Component<OriginalProps & EditableProps, State> {
       static contextTypes = {
-        tux: React.PropTypes.object,
-        tuxModel: React.PropTypes.object,
+        tux: PropTypes.object,
+        tuxModel: PropTypes.object,
       }
 
       static childContextTypes = {
-        tuxModel: React.PropTypes.object,
+        tuxModel: PropTypes.object,
       }
 
       getChildContext() {

--- a/packages/tux/src/components/ModelCreator/ModelCreator.tsx
+++ b/packages/tux/src/components/ModelCreator/ModelCreator.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import classNames from 'classnames'
 
 import { openModal } from '../TuxModalContainer'
@@ -11,7 +12,7 @@ export interface ModelCreatorProps {
 
 class ModelCreator extends React.Component<ModelCreatorProps, any> {
   static contextTypes = {
-    tux: React.PropTypes.object,
+    tux: PropTypes.object,
   }
 
   shouldBeVisible() {

--- a/packages/tux/src/components/TuxFab/TuxFab.tsx
+++ b/packages/tux/src/components/TuxFab/TuxFab.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { lighten, fade } from '../../utils/color'
 import { Theme } from '../../theme'
@@ -20,7 +21,7 @@ const FabEase = '0,.62,.45,1.13'
 
 class TuxFab extends React.Component<any, State> {
   static contextTypes = {
-    tux: React.PropTypes.object,
+    tux: PropTypes.object,
   }
 
   state: State = {

--- a/packages/tux/src/components/TuxModal/TuxModal.tsx
+++ b/packages/tux/src/components/TuxModal/TuxModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 import { Theme, input, button } from '../../theme'
 import { fade } from '../../utils/color'
@@ -24,7 +25,7 @@ export interface TuxModalProps {
 
 class TuxModal extends React.Component<TuxModalProps, State> {
   static contextTypes = {
-    tux: React.PropTypes.object,
+    tux: PropTypes.object,
   }
 
   state: State = {

--- a/packages/tux/src/components/TuxProvider/TuxProvider.admin.tsx
+++ b/packages/tux/src/components/TuxProvider/TuxProvider.admin.tsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import ModalContainer, { openModal } from '../TuxModalContainer'
 import TuxFab from '../TuxFab'
 import TuxModal from '../TuxModal'
@@ -13,10 +14,10 @@ export interface TuxProviderProps {
 
 class TuxProvider extends Component<TuxProviderProps, any> {
   static childContextTypes = {
-    tux: React.PropTypes.shape({
-      isEditing: React.PropTypes.bool.isRequired,
-      editModel: React.PropTypes.func.isRequired,
-      adapter: React.PropTypes.object.isRequired,
+    tux: PropTypes.shape({
+      isEditing: PropTypes.bool.isRequired,
+      editModel: PropTypes.func.isRequired,
+      adapter: PropTypes.object.isRequired,
     }),
   }
 

--- a/packages/tux/src/components/TuxProvider/TuxProvider.tsx
+++ b/packages/tux/src/components/TuxProvider/TuxProvider.tsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import adminOnly from '../../utils/adminOnly'
 
 export interface TuxProviderProps {
@@ -7,10 +8,10 @@ export interface TuxProviderProps {
 
 class TuxProvider extends Component<TuxProviderProps, any> {
   static childContextTypes = {
-    tux: React.PropTypes.shape({
-      isEditing: React.PropTypes.bool.isRequired,
-      editModel: React.PropTypes.func.isRequired,
-      adapter: React.PropTypes.object.isRequired,
+    tux: PropTypes.shape({
+      isEditing: PropTypes.bool.isRequired,
+      editModel: PropTypes.func.isRequired,
+      adapter: PropTypes.object.isRequired,
     }),
   }
 

--- a/packages/tux/src/components/fields/ImageField.tsx
+++ b/packages/tux/src/components/fields/ImageField.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import { get } from '../../utils/accessors'
 import { input } from '../../theme'
@@ -16,7 +17,7 @@ export interface ImageFieldProps {
 
 class ImageField extends React.Component<ImageFieldProps, any> {
   static contextTypes = {
-    tux: React.PropTypes.object,
+    tux: PropTypes.object,
   }
 
   constructor(props: ImageFieldProps) {


### PR DESCRIPTION
On a fresh setup with `tux new amazing-project` I get this sad warning, which is understandable given React's [recent deprecation warnings](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes) in preparation for React 16

`Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.`

So I added prop-types as a root dependency (since more than one package seem to need it) and update every usage I could find to use the new `prop-types` package. I'm not used to working with typescript, and Sublime kept pestering me about not finding a declaration file for module `prop-types`, but I couldn't find anything about it anywhere so I decided to go ahead with the PR anyways and we can just figure it out.