### PR TITLE
Add react-icons as a dependency for Tux

### DIFF
--- a/packages/tux/package.json
+++ b/packages/tux/package.json
@@ -32,6 +32,7 @@
     "moment": "^2.17.1",
     "react-addons-css-transition-group": "^15.4.2",
     "react-day-picker": "^5.1.1",
+    "react-icons": "^2.2.3",
     "string-humanize": "^1.0.0",
     "styled-jsx": "^0.5.4"
   },


### PR DESCRIPTION
Currently a fresh Tux app will fail because this dependency is missing.