### PR TITLE
Add support for Neutrino presets in package.json

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -25,7 +25,20 @@ On top of this, Tux adds:
 * Environment variables to detect BROWSER, SERVER and ADMIN builds and remove unused code.
 * Automatic creation of HTML pages using a [React Document](https://www.npmjs.com/package/react-document) component.
 
-**Note:** Tux does not currently support additional Neutrino presets or configuration in package.json. Check out [the issue](https://github.com/aranja/tux/issues/104) for information and progress.
+Tux supports additional Neutrino presets in package.json.
+
+```json
+{
+  "neutrino": {
+    "use": [
+      "neutrino-preset-something"
+    ]
+  }
+}
+```
+
+**Note:** Tux does not currently support Neutrino configuration in package.json. Check out [the issue](https://github.com/aranja/tux/issues/104) for information and progress.
+
 
 ## Rendering
 

--- a/packages/tux-scripts/bin/tux-scripts
+++ b/packages/tux-scripts/bin/tux-scripts
@@ -18,6 +18,7 @@ const args = yargs
   .option('ssr', { describe: 'Include server-side-rendering', type: 'boolean' })
   .option('admin', { describe: 'Include admin functionality', type: 'boolean' })
   .option('port', { describe: 'Server port', type: 'number', defaultDescription: '3000' })
+  .option('use', { describe: 'A list of Neutrino middleware used to configure the build', array: true, default: [], global: true })
   .option('env', { describe: 'The value for the environment variable, NODE_ENV', string: true, global: true })
   .command('build', 'Build project for production')
   .command('start', 'Build and serve a project in development mode')

--- a/packages/tux-scripts/bin/tux-scripts
+++ b/packages/tux-scripts/bin/tux-scripts
@@ -18,6 +18,7 @@ const args = yargs
   .option('ssr', { describe: 'Include server-side-rendering', type: 'boolean' })
   .option('admin', { describe: 'Include admin functionality', type: 'boolean' })
   .option('port', { describe: 'Server port', type: 'number', defaultDescription: '3000' })
+  .option('env', { describe: 'The value for the environment variable, NODE_ENV', string: true, global: true })
   .command('build', 'Build project for production')
   .command('start', 'Build and serve a project in development mode')
   .command('serve [path]', 'Serve a build')

--- a/packages/tux-scripts/src/commands/build.ts
+++ b/packages/tux-scripts/src/commands/build.ts
@@ -6,7 +6,7 @@ import { CliOptions } from '../options'
 export default async (options: CliOptions) => {
   const {
     ssr = true,
-    admin = false,
+    admin = !!process.env.ADMIN,
   } = options
   process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 

--- a/packages/tux-scripts/src/commands/build.ts
+++ b/packages/tux-scripts/src/commands/build.ts
@@ -8,7 +8,7 @@ export default async (options: CliOptions) => {
     ssr = true,
     admin = !!process.env.ADMIN,
   } = options
-  process.env.NODE_ENV = process.env.NODE_ENV || 'production'
+  process.env.NODE_ENV = options.env || process.env.NODE_ENV || 'production'
 
   const spinner = ora('Building project').start()
   let result

--- a/packages/tux-scripts/src/commands/build.ts
+++ b/packages/tux-scripts/src/commands/build.ts
@@ -7,13 +7,14 @@ export default async (options: CliOptions) => {
   const {
     ssr = true,
     admin = !!process.env.ADMIN,
+    use,
   } = options
   process.env.NODE_ENV = options.env || process.env.NODE_ENV || 'production'
 
   const spinner = ora('Building project').start()
   let result
   try {
-    result = await run('build', { ssr, admin }) as Stats[]
+    result = await run('build', { ssr, admin, use }) as Stats[]
   } catch (err) {
     spinner.fail('Building project failed')
     throw err

--- a/packages/tux-scripts/src/commands/start.ts
+++ b/packages/tux-scripts/src/commands/start.ts
@@ -7,6 +7,7 @@ export default async (options: CliOptions) => {
   const {
     ssr = false,
     admin = process.env.ADMIN !== '',
+    use,
     port,
     host,
   } = options
@@ -15,7 +16,7 @@ export default async (options: CliOptions) => {
   const spinner = ora('Building project').start()
   let compilers
   try {
-    compilers = await run('start', { ssr, admin, port, host }) as Compiler[]
+    compilers = await run('start', { ssr, admin, port, host, use }) as Compiler[]
   } catch (err) {
     spinner.fail('Building project failed')
     throw err

--- a/packages/tux-scripts/src/commands/start.ts
+++ b/packages/tux-scripts/src/commands/start.ts
@@ -6,7 +6,7 @@ import { CliOptions } from '../options'
 export default async (options: CliOptions, buildPath: string) => {
   const {
     ssr = false,
-    admin = true,
+    admin = process.env.ADMIN !== '',
     port,
     host,
   } = options

--- a/packages/tux-scripts/src/commands/start.ts
+++ b/packages/tux-scripts/src/commands/start.ts
@@ -3,14 +3,14 @@ import { Compiler } from 'webpack'
 import { run } from '../compiler'
 import { CliOptions } from '../options'
 
-export default async (options: CliOptions, buildPath: string) => {
+export default async (options: CliOptions) => {
   const {
     ssr = false,
     admin = process.env.ADMIN !== '',
     port,
     host,
   } = options
-  process.env.NODE_ENV = process.env.NODE_ENV || 'development'
+  process.env.NODE_ENV = options.env || process.env.NODE_ENV || 'development'
 
   const spinner = ora('Building project').start()
   let compilers

--- a/packages/tux-scripts/src/compiler.ts
+++ b/packages/tux-scripts/src/compiler.ts
@@ -8,25 +8,25 @@ import { Options } from './options'
 
 type Command = 'inspect' | 'build' | 'start'
 
-export async function run(command: Command, options: Options) {
-  const neutrinoOptions = await getOptions(options)
+export async function run(command: Command, args: Options) {
+  const options = await getOptions(args)
   const builders = []
 
-  builders.push(runNeutrino(command, tuxStaticPreset, neutrinoOptions))
-  if (options.ssr) {
-    builders.push(runNeutrino(command, tuxSsrPreset, neutrinoOptions))
+  builders.push(runNeutrino(command, tuxStaticPreset, options))
+  if (args.ssr) {
+    builders.push(runNeutrino(command, tuxSsrPreset, options))
   }
 
   return Promise.all(builders)
 }
 
 async function runNeutrino(command: Command, middleware: Middleware, options: any) {
-  const neutrino = new Neutrino(options)
+  const neutrino = new Neutrino(options.neutrinoOptions)
 
   neutrino.use(middleware)
 
-  if (options.neutrino.use) {
-    await neutrino.requiresAndUses(options.neutrino.use).promise()
+  if (options.use) {
+    await neutrino.requiresAndUses(options.use).promise()
   }
 
   const result = await neutrino.run(command)
@@ -40,25 +40,26 @@ async function getOptions(options: Options) {
   const { host, port, admin } = options
   const cwd = process.cwd()
   const pkg = optional(join(cwd, 'package.json')) || {}
-  const neutrino = pkg.neutrino || {}
   let document = pathOr(null, ['tux', 'document'], pkg)
   if (document) {
     document = resolve(document)
   }
 
   return {
-    config: {
-      devServer: {
-        host,
-        port,
+    use: pathOr([], ['neutrino', 'use'], pkg).concat(options.use),
+    neutrinoOptions: {
+      tux: {
+        admin,
       },
-    },
-    tux: {
-      admin,
-    },
-    html: {
-      document,
-    },
-    neutrino,
-  };
+      html: {
+        document,
+      },
+      config: {
+        devServer: {
+          host,
+          port,
+        },
+      },
+    }
+  }
 }

--- a/packages/tux-scripts/src/compiler.ts
+++ b/packages/tux-scripts/src/compiler.ts
@@ -54,11 +54,13 @@ async function getOptions(options: Options) {
       html: {
         document,
       },
+      ...pathOr({}, ['neutrino', 'options'], pkg),
       config: {
         devServer: {
           host,
           port,
         },
+        ...pathOr({}, ['neutrino', 'config'], pkg),
       },
     }
   }

--- a/packages/tux-scripts/src/options.ts
+++ b/packages/tux-scripts/src/options.ts
@@ -3,6 +3,7 @@ export interface Options {
   admin?: boolean,
   port?: number,
   host?: string,
+  use: string[],
 }
 
 export interface CliOptions extends Options {

--- a/packages/tux-scripts/src/options.ts
+++ b/packages/tux-scripts/src/options.ts
@@ -6,4 +6,5 @@ export interface Options {
 }
 
 export interface CliOptions extends Options {
+  env?: string,
 }

--- a/shared/types/neutrino.d.ts
+++ b/shared/types/neutrino.d.ts
@@ -28,6 +28,7 @@ declare module 'neutrino' {
     run(command: 'start'): Future<Compiler>
     run(command: 'inspect'): Future<string>
     run(command: 'build' | 'start' | 'inspect'): Future<Stats | Compiler | string>
+    requiresAndUses(middleware: string[]): Future<any>
   }
 
   export function run(command: string, middleware: any[], options: Options | any): Future<any>


### PR DESCRIPTION
Add Neutrino presets and/or middlewares to package.json and tux-scripts will use them.

Fixes a part of #104, Neutrino configuration still missing.