### PR TITLE
RichTextField and Text Editor HOC

### DIFF
--- a/packages/tux-adapter-contentful/src/editors.ts
+++ b/packages/tux-adapter-contentful/src/editors.ts
@@ -6,9 +6,9 @@ import {
   ImageField,
   MarkdownField,
   Radio,
-  RichTextField,
   Input,
   TagEditor,
+  RichTextField,
 } from 'tux'
 
 const widgetIdToEditor: {[id: string]: ReactType | undefined} = {

--- a/packages/tux-adapter-contentful/src/editors.ts
+++ b/packages/tux-adapter-contentful/src/editors.ts
@@ -6,6 +6,7 @@ import {
   ImageField,
   MarkdownField,
   Radio,
+  RichTextField,
   Input,
   TagEditor,
 } from 'tux'
@@ -19,6 +20,7 @@ const widgetIdToEditor: {[id: string]: ReactType | undefined} = {
   radio: Radio,
   singleLine: Input,
   tagEditor: TagEditor,
+  objectEditor: RichTextField,
 }
 
 export default function generateEditorSchema(typeMeta: any) {
@@ -27,7 +29,6 @@ export default function generateEditorSchema(typeMeta: any) {
 
 function _transformTypeMetaFieldToEditorField(typeMetaField: any) {
   const props = _getPropsForType(typeMetaField)
-
   return {
     field: `fields.${typeMetaField.id}`,
     label: typeMetaField.name,

--- a/packages/tux/src/components/EditInline/EditInline.admin.tsx
+++ b/packages/tux/src/components/EditInline/EditInline.admin.tsx
@@ -72,8 +72,8 @@ class EditInline extends React.Component<Props> {
     await tux.adapter.save(fullModel)
   }
 
-  onChange = async (editorState: any) => {
-    const { onEditorChange } = this.props
+  onChange = async () => {
+    const { onEditorChange, editorState } = this.props
     onEditorChange(editorState)
 
     if (this.timer) {
@@ -83,7 +83,7 @@ class EditInline extends React.Component<Props> {
   }
 
   render() {
-    const { editorState, onPaste, onKeyDown, onClickMark, isEditing, placeholder } = this.props
+    const { editorState, onEditorChange, onPaste, onKeyDown, onClickMark, isEditing, placeholder } = this.props
 
     if (!isEditing && !editorState.document.length) {
       return null
@@ -94,7 +94,7 @@ class EditInline extends React.Component<Props> {
         <HoverPortal editorState={editorState} onClickMark={onClickMark} />
         <SlateRenderer
           state={editorState}
-          onChange={this.onChange}
+          onChange={onEditorChange}
           readOnly={!isEditing}
           placeholder={placeholder || this.defaultPlaceholder()}
           onKeyDown={onKeyDown}

--- a/packages/tux/src/components/EditInline/EditInline.admin.tsx
+++ b/packages/tux/src/components/EditInline/EditInline.admin.tsx
@@ -84,7 +84,7 @@ class EditInline extends React.Component<Props, State> {
   /**
    * Paste handler.
    */
-  onPaste = (e, data, state) => {
+  onPaste = (event, data, state) => {
     if (data.type !== 'html') return
     if (data.isShift) return
     const { document } = Html.deserialize(data.html)
@@ -97,7 +97,7 @@ class EditInline extends React.Component<Props, State> {
   /**
    * On key down, if it's a formatting command toggle a mark.
    */
-  onKeyDown = (e, data, state) => {
+  onKeyDown = (event, data, state) => {
     if (!data.isMod) return
     let mark
 
@@ -123,15 +123,15 @@ class EditInline extends React.Component<Props, State> {
       .toggleMark(mark)
       .apply()
 
-    e.preventDefault()
+    event.preventDefault()
     return state
   }
 
   /**
    * Click handler for HoverPortal
    */
-  onClickMark = (e, type) => {
-    e.preventDefault()
+  onClickMark = (event, type) => {
+    event.preventDefault()
     let { editorState } = this.state
 
     editorState = editorState.transform().toggleMark(type).apply()

--- a/packages/tux/src/components/EditInline/EditInline.admin.tsx
+++ b/packages/tux/src/components/EditInline/EditInline.admin.tsx
@@ -6,7 +6,7 @@ import SlateRenderer from './SlateRenderer'
 import HoverPortal from './HoverPortal'
 import { createEditable } from '../Editable/Editable'
 import { EditableProps } from '../../interfaces'
-import { Raw, Plain, State, Html as HtmlSerializer } from 'slate'
+import { Raw, Plain } from 'slate'
 import { Html } from '../../utils/slate'
 import { get, set } from '../../utils/accessors'
 

--- a/packages/tux/src/components/EditInline/EditInline.admin.tsx
+++ b/packages/tux/src/components/EditInline/EditInline.admin.tsx
@@ -7,6 +7,7 @@ import HoverPortal from './HoverPortal'
 import { createEditable } from '../Editable/Editable'
 import { EditableProps } from '../../interfaces'
 import { Raw, Plain, State, Html as HtmlSerializer } from 'slate'
+import { Html } from '../../utils/slate'
 import { get, set } from '../../utils/accessors'
 
 export interface Props extends EditableProps {
@@ -19,98 +20,6 @@ export interface Props extends EditableProps {
 export interface State {
   editorState: any,
 }
-
-/**
- * Tags to blocks.
- */
-const BLOCK_TAGS : { [key: string]: string } = {
-  p: 'paragraph',
-  li: 'list-item',
-  ul: 'bulleted-list',
-  ol: 'numbered-list',
-  blockquote: 'quote',
-  pre: 'code',
-  h1: 'heading-one',
-  h2: 'heading-two',
-  h3: 'heading-three',
-  h4: 'heading-four',
-  h5: 'heading-five',
-  h6: 'heading-six'
-}
-
-/**
- * Tags to marks.
- */
-const MARK_TAGS : { [key: string]: string } = {
-  strong: 'bold',
-  em: 'italic',
-  u: 'underline',
-  s: 'strikethrough',
-  code: 'code'
-}
-
-/**
- * Serializer rules.
- */
-const RULES = [
-  {
-    deserialize(el, next) {
-      const block = BLOCK_TAGS[el.tagName.toLowerCase()]
-      if (!block) return
-      return {
-        kind: 'block',
-        type: block,
-        nodes: next(el.childNodes)
-      }
-    }
-  },
-  {
-    deserialize(el, next) {
-      const mark = MARK_TAGS[el.tagName.toLowerCase()]
-      if (!mark) return
-      return {
-        kind: 'mark',
-        type: mark,
-        nodes: next(el.childNodes)
-      }
-    }
-  },
-  {
-    // Special case for code blocks, which need to grab the nested childNodes.
-    deserialize(el, next) {
-      if (el.tagName.toLowerCase() !== 'pre') return
-      const code = el.childNodes[0]
-      const childNodes = code && code.tagName.toLowerCase() === 'code'
-        ? code.childNodes
-        : el.childNodes
-
-      return {
-        kind: 'block',
-        type: 'code',
-        nodes: next(childNodes)
-      }
-    }
-  },
-  {
-    // Special case for links, to grab their href.
-    deserialize(el, next) {
-      if (el.tagName.toLowerCase() !== 'a') return
-      return {
-        kind: 'inline',
-        type: 'link',
-        nodes: next(el.childNodes),
-        data: {
-          href: el.getAttribute('href'),
-        }
-      }
-    }
-  }
-]
-
-/**
- * Create a new HTML serializer with `RULES`.
- */
-export const Html = new HtmlSerializer({ rules: RULES })
 
 class EditInline extends React.Component<Props, State> {
   constructor(props: Props, context: any) {
@@ -217,6 +126,9 @@ class EditInline extends React.Component<Props, State> {
     return state
   }
 
+  /**
+   * Click handler for HoverPortal
+   */
   onClickMark = (e, type) => {
     e.preventDefault()
     let { editorState } = this.state

--- a/packages/tux/src/components/EditInline/EditInline.admin.tsx
+++ b/packages/tux/src/components/EditInline/EditInline.admin.tsx
@@ -28,6 +28,7 @@ class EditInline extends React.Component<Props, State> {
     this.state = {
       editorState: this.getInitialState(),
     }
+
   }
 
   getInitialState() {

--- a/packages/tux/src/components/EditInline/EditInline.admin.tsx
+++ b/packages/tux/src/components/EditInline/EditInline.admin.tsx
@@ -6,38 +6,32 @@ import SlateRenderer from './SlateRenderer'
 import HoverPortal from './HoverPortal'
 import { createEditable } from '../Editable/Editable'
 import { EditableProps } from '../../interfaces'
-import { Raw, Plain } from 'slate'
+import { Raw, Plain, State, Html as HtmlSerializer } from 'slate'
 import { Html } from '../../utils/slate'
 import { get, set } from '../../utils/accessors'
+import withEditorState from '../HOC/withEditorState'
 
 export interface Props extends EditableProps {
   onSave: (model: any) => Promise<any>,
   onLoad: (model: any) => void,
   placeholder: string,
   field: string | Array<string>,
-}
-
-export interface State {
   editorState: any,
+  onPaste: Function,
+  onClickMark: Function,
+  onClickNode: Function,
+  onEditorChange: Function,
+  onKeyDown: Function,
 }
 
-class EditInline extends React.Component<Props, State> {
-  constructor(props: Props, context: any) {
-    super(props, context)
-
-    this.state = {
-      editorState: this.getInitialState(),
-    }
-
-  }
-
-  getInitialState() {
-    const value = get(this.props.model, this.props.field)
+class EditInline extends React.Component<Props> {
+  static getInitialState(props) {
+    const value = get(props.model, props.field)
     try {
       if (value) {
         return Raw.deserialize(value, { terse: true })
-      } else if (this.props.children) {
-        const html = renderToStaticMarkup(this.props.children)
+      } else if (props.children) {
+        const html = renderToStaticMarkup(props.children)
         return Html.deserialize(html)
       }
     } catch (err) {
@@ -48,6 +42,12 @@ class EditInline extends React.Component<Props, State> {
 
   private timer: number
 
+  componentDidUpdate(oldProps) {
+    if (oldProps.editorState !== this.props.editorState) {
+      this.save()
+    }
+  }
+
   defaultPlaceholder() {
     let { field } = this.props
     if (typeof field === 'string') {
@@ -57,8 +57,7 @@ class EditInline extends React.Component<Props, State> {
   }
 
   private save = async () => {
-    const { tux, model, field } = this.props
-    const { editorState } = this.state
+    const { editorState, tux, model, field } = this.props
     const oldValue = get(model, field)
     const newValue = Raw.serialize(editorState, { terse: true })
 
@@ -73,89 +72,33 @@ class EditInline extends React.Component<Props, State> {
     await tux.adapter.save(fullModel)
   }
 
-  onEditorChange = async (editorState: any) => {
-    this.setState({ editorState })
+  onChange = async (editorState: any) => {
+    const { onEditorChange } = this.props
+    onEditorChange(editorState)
+
     if (this.timer) {
       window.clearTimeout(this.timer)
     }
     this.timer = window.setTimeout(this.save, 2000)
   }
 
-  /**
-   * Paste handler.
-   */
-  onPaste = (event, data, state) => {
-    if (data.type !== 'html') return
-    if (data.isShift) return
-    const { document } = Html.deserialize(data.html)
-    return state
-      .transform()
-      .insertFragment(document)
-      .apply()
-  }
-
-  /**
-   * On key down, if it's a formatting command toggle a mark.
-   */
-  onKeyDown = (event, data, state) => {
-    if (!data.isMod) return
-    let mark
-
-    switch (data.key) {
-      case 'b':
-        mark = 'bold'
-        break
-      case 'i':
-        mark = 'italic'
-        break
-      case 'u':
-        mark = 'underlined'
-        break
-      case '`':
-        mark = 'code'
-        break
-      default:
-        return
-    }
-
-    state = state
-      .transform()
-      .toggleMark(mark)
-      .apply()
-
-    event.preventDefault()
-    return state
-  }
-
-  /**
-   * Click handler for HoverPortal
-   */
-  onClickMark = (event, type) => {
-    event.preventDefault()
-    let { editorState } = this.state
-
-    editorState = editorState.transform().toggleMark(type).apply()
-
-    this.setState({ editorState })
-  }
-
   render() {
-    const { isEditing, placeholder } = this.props
-    const { editorState } = this.state
+    const { editorState, onPaste, onKeyDown, onClickMark, isEditing, placeholder } = this.props
+
     if (!isEditing && !editorState.document.length) {
       return null
     }
 
     return (
       <div className={`EditInline${isEditing ? ' is-editing' : ''}`}>
-        <HoverPortal editorState={editorState} onClickMark={this.onClickMark} />
+        <HoverPortal editorState={editorState} onClickMark={onClickMark} />
         <SlateRenderer
           state={editorState}
-          onChange={this.onEditorChange}
+          onChange={this.onChange}
           readOnly={!isEditing}
           placeholder={placeholder || this.defaultPlaceholder()}
-          onKeyDown={this.onKeyDown}
-          onPaste={this.onPaste}
+          onKeyDown={onKeyDown}
+          onPaste={onPaste}
         />
         <style jsx>{`
           .EditInline.is-editing:hover {
@@ -169,4 +112,5 @@ class EditInline extends React.Component<Props, State> {
   }
 }
 
-export default createEditable<Props>()(EditInline)
+const Exported = withEditorState(EditInline, EditInline.getInitialState)
+export default createEditable<Props>()(Exported)

--- a/packages/tux/src/components/EditInline/HoverPortal.tsx
+++ b/packages/tux/src/components/EditInline/HoverPortal.tsx
@@ -5,10 +5,6 @@ import FaItalic from 'react-icons/lib/fa/italic'
 import FaCode from 'react-icons/lib/fa/code'
 import FaUnderline from 'react-icons/lib/fa/underline'
 
-export interface State {
-  editorState: any
-}
-
 class HoverPortal extends React.Component {
   constructor(props) {
     super(props)

--- a/packages/tux/src/components/EditInline/SlateRenderer.tsx
+++ b/packages/tux/src/components/EditInline/SlateRenderer.tsx
@@ -42,6 +42,7 @@ const schema = {
 const SlateRenderer = (props: Props) => {
   return (
     <Editor
+      style={{width: '100%'}}
       schema={schema}
       {...props}
     />

--- a/packages/tux/src/components/HOC/withEditorState.tsx
+++ b/packages/tux/src/components/HOC/withEditorState.tsx
@@ -61,12 +61,11 @@ export default function withEditorState(Component, getInitialEditorState) {
     onClickMark = (event, type) => {
       event.preventDefault()
       let { editorState } = this.state
-      
       editorState = editorState.transform().toggleMark(type).apply()
-      
+
       this.setState({ editorState })
     }
-    
+
     onClickNode = (event, type) => {
       event.preventDefault()
     }

--- a/packages/tux/src/components/HOC/withEditorState.tsx
+++ b/packages/tux/src/components/HOC/withEditorState.tsx
@@ -73,8 +73,8 @@ export default function withEditorState(Component, getInitialEditorState) {
       this.setState({ editorState })
     }
 
-    onClickBlock = (e, type) => {
-      e.preventDefault()
+    onClickBlock = (event, type) => {
+      event.preventDefault()
       let { editorState } = this.state
       const transform = editorState.transform()
       const { document } = editorState
@@ -119,8 +119,6 @@ export default function withEditorState(Component, getInitialEditorState) {
       }
 
       editorState = transform.apply()
-      console.log('editorState after')
-      console.log(editorState)
       this.setState({ editorState })
     }
 

--- a/packages/tux/src/components/HOC/withEditorState.tsx
+++ b/packages/tux/src/components/HOC/withEditorState.tsx
@@ -6,7 +6,7 @@ import { Html } from '../../utils/slate'
 
 export default function withEditorState(Component, getInitialEditorState) {
   return class extends React.Component {
-    constructor(props: Props, context: any) {
+    constructor(props: any, context: any) {
       super(props, context)
 
       this.state = {
@@ -20,7 +20,7 @@ export default function withEditorState(Component, getInitialEditorState) {
     }
 
     hasMark = type => {
-      const { editorState } = this.props
+      const { editorState } = this.state
       return editorState.marks.some(mark => mark.type === type)
     }
 

--- a/packages/tux/src/components/HOC/withEditorState.tsx
+++ b/packages/tux/src/components/HOC/withEditorState.tsx
@@ -62,6 +62,7 @@ export default function withEditorState(Component, getInitialEditorState) {
     }
 
     onEditorChange = async (editorState: any) => {
+      const { onChange, id } = this.props
       this.setState({ editorState })
     }
 

--- a/packages/tux/src/components/HOC/withEditorState.tsx
+++ b/packages/tux/src/components/HOC/withEditorState.tsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { Raw, Plain } from 'slate'
+import { Html } from '../../utils/slate'
+
+export default function withEditorState(Component, getInitialEditorState) {
+  return class extends React.Component {
+    constructor(props: Props, context: any) {
+      super(props, context)
+      console.log(getInitialEditorState)
+
+      this.state = {
+        editorState: getInitialEditorState(props)
+      }
+    }
+
+    componentDidMount() {
+      console.log(this.state)
+    }
+
+    /**
+     * On key down, if it's a formatting command toggle a mark.
+     */
+    onKeyDown = (event, data, state) => {
+      if (!data.isMod) return
+      let mark
+
+      switch (data.key) {
+        case 'b':
+          mark = 'bold'
+          break
+        case 'i':
+          mark = 'italic'
+          break
+        case 'u':
+          mark = 'underlined'
+          break
+        default:
+          return
+      }
+
+      state = state.transform().toggleMark(mark).apply()
+
+      event.preventDefault()
+      return state
+    }
+
+    onEditorChange = async (editorState: any, id) => {
+      const { onChange } = this.props
+      this.setState({ editorState })
+      onChange(Raw.serialize(editorState), id)
+    }
+
+
+    onClickMark = (event, type) => {
+      event.preventDefault()
+      let { editorState } = this.state
+
+      editorState = editorState.transform().toggleMark(type).apply()
+
+      this.setState({ editorState })
+    }
+
+    onClickNode = (event, type) => {
+      // Todo
+    }
+
+    render() {
+      const { children, ...rest } = this.props
+      const { editorState } = this.state
+
+      return (
+        <Component
+          editorState={editorState}
+          onEditorChange={this.onEditorChange}
+          onClickMark={this.onClickMark}
+          onClickNode={this.onClickNode}
+          onEditorChange={this.onEditorChange}
+          onKeyDown={this.onKeyDown}
+          {...rest}
+        >
+          {children}
+        </Component>
+      )
+    }
+  }
+}

--- a/packages/tux/src/components/TuxModal/TuxModal.tsx
+++ b/packages/tux/src/components/TuxModal/TuxModal.tsx
@@ -178,8 +178,7 @@ class TuxModal extends React.Component<TuxModalProps, State> {
           }
 
           .TuxModal-meta {
-            font-size: 16px;
-            margin-bottom: 20px;
+            font-size: 12px;
             text-align: right;
           }
 

--- a/packages/tux/src/components/fields/BrowseField.tsx
+++ b/packages/tux/src/components/fields/BrowseField.tsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import FaImage from 'react-icons/lib/fa/image'
 import { button } from '../../theme'
 import { lighten } from '../../utils/color'
 
@@ -29,7 +28,6 @@ class BrowseField extends Component<any, any> {
           aria-label="Browse for files"
           htmlFor={id}>
             Browse for files
-            <FaImage className="BrowseField-icon" />
         </label>
         <input
           className="BrowseField-fileInput"
@@ -46,11 +44,6 @@ class BrowseField extends Component<any, any> {
             height: 0;
             width: 0;
             overflow: hidden;
-          }
-
-          .BrowseField-icon {
-            margin-bottom: 1px;
-            margin-left: 6px;
           }
 
           .BrowseField-button {

--- a/packages/tux/src/components/fields/RichTextField.tsx
+++ b/packages/tux/src/components/fields/RichTextField.tsx
@@ -28,16 +28,7 @@ export interface Props extends EditableProps {
   editorState: any
 }
 
-
 class RichTextField extends React.Component<Props> {
-  constructor(props: Props, context: any) {
-    super(props, context)
-  }
-
-  componentDidMount() {
-    console.log(this.props)
-  }
-
   static getInitialEditorState(props) {
     const { value } = props
 
@@ -55,8 +46,14 @@ class RichTextField extends React.Component<Props> {
   }
 
   onChange = async (editorState: any) => {
-    const { id, onEditorChange } = this.props
-    onEditorChange(editorState, id)
+    const { onEditorChange } = this.props
+    onEditorChange(editorState)
+  }
+
+  componentDidUpdate(oldProps) {
+    if (oldProps.editorState !== this.props.editorState) {
+      this.onChange()
+    }
   }
 
   hasMark = type => {

--- a/packages/tux/src/components/fields/RichTextField.tsx
+++ b/packages/tux/src/components/fields/RichTextField.tsx
@@ -52,8 +52,9 @@ class RichTextField extends React.Component<Props> {
   }
 
   onChange = async () => {
-    const { onEditorChange, editorState } = this.props
+    const { onEditorChange, editorState, onChange, id } = this.props
     onEditorChange(editorState)
+    onChange(Raw.serialize(editorState), id)
   }
 
   renderBlockButton(type, icon) {

--- a/packages/tux/src/components/fields/RichTextField.tsx
+++ b/packages/tux/src/components/fields/RichTextField.tsx
@@ -56,7 +56,6 @@ class RichTextField extends React.Component<Props> {
     onEditorChange(editorState)
   }
 
-
   renderBlockButton(type, icon) {
     const { onClickBlock, hasBlock } = this.props
     const isActive = hasBlock(type)
@@ -124,10 +123,7 @@ class RichTextField extends React.Component<Props> {
   }
 
   render() {
-    const { editorState, onEditorChange, value, isEditing, placeholder, onKeyDown } = this.props
-    if (!isEditing && !editorState.document.length) {
-      return null
-    }
+    const { editorState, onEditorChange, isEditing, placeholder, onKeyDown } = this.props
     return (
       <div className="RichTextField">
         <div className="RichTextField-toolbar">

--- a/packages/tux/src/components/fields/RichTextField.tsx
+++ b/packages/tux/src/components/fields/RichTextField.tsx
@@ -1,0 +1,84 @@
+import React from 'react'
+import { Raw, Plain, State, Html as HtmlSerializer } from 'slate'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { Theme, input, button } from '../../theme'
+import SlateRenderer from '../EditInline/SlateRenderer'
+import { get, set } from '../../utils/accessors'
+import { Html } from '../../utils/slate'
+import { EditableProps } from '../../interfaces'
+
+export interface Props extends EditableProps {
+  value: string,
+}
+
+export interface State {
+  editorState: any
+}
+
+class RichTextField extends React.Component<Props, State> {
+  constructor(props: Props, context: any) {
+    super(props, context)
+
+    this.state = {
+      editorState: this.getInitialState()
+    }
+  }
+
+  getInitialState() {
+    const { value } = this.props
+
+    try {
+      if (value) {
+        return Raw.deserialize(value, { terse: true })
+      } else if (this.props.children) {
+        const html = renderToStaticMarkup(this.props.children)
+        return Html.deserialize(html)
+      }
+    } catch (err) {
+      console.error('Could not parse content', value, err)
+    }
+    return Plain.deserialize('')
+  }
+
+  onEditorChange = async (editorState: any) => {
+    this.setState({ editorState })
+  }
+
+  render() {
+    const { id, value, onChange } = this.props
+    const { editorState } = this.state
+
+    return (
+      <div className="RichTextField">
+        <div className="RichTextField-toolbar">
+          Toolbar here
+        </div>
+        <div className="RichTextField-editor">
+          <SlateRenderer state={editorState} onChange={this.onEditorChange} />
+        </div>
+        <style jsx>{`
+          .RichTextField {
+            align-items: baseline;
+            display: flex;
+            flex-direction: column;
+            flex-wrap: wrap;
+          }
+
+          .RichTextField-editor {
+            background: #fff;
+            border: 1px solid ${input.border};
+            color: ${Theme.textDark};
+            font-size: 16px;
+            font-weight: 400;
+            font-family: initial;
+            line-height: 1.5;
+            padding: 8px;
+            width: 100%;
+          }
+        `}</style>
+      </div>
+    )
+  }
+}
+
+export default RichTextField

--- a/packages/tux/src/components/fields/RichTextField.tsx
+++ b/packages/tux/src/components/fields/RichTextField.tsx
@@ -1,14 +1,29 @@
 import React from 'react'
 import { Raw, Plain, State, Html as HtmlSerializer } from 'slate'
 import { renderToStaticMarkup } from 'react-dom/server'
+import deepEqual from 'deep-eql'
 import { Theme, input, button } from '../../theme'
 import SlateRenderer from '../EditInline/SlateRenderer'
 import { get, set } from '../../utils/accessors'
 import { Html } from '../../utils/slate'
 import { EditableProps } from '../../interfaces'
+import { createEditable } from '../Editable/Editable'
+
+// icons
+import FaBold from 'react-icons/lib/fa/bold'
+import FaItalic from 'react-icons/lib/fa/italic'
+import FaUnderline from 'react-icons/lib/fa/underline'
+import FaQuoteRight from 'react-icons/lib/fa/quote-right'
+import FaListUl from 'react-icons/lib/fa/list-ul'
+import FaListOl from 'react-icons/lib/fa/list-ol'
 
 export interface Props extends EditableProps {
-  value: string,
+  value: any
+  id: string
+  placeholder: string
+  field: string | Array<string>
+  onChange: Function
+  isEditing: boolean
 }
 
 export interface State {
@@ -40,21 +55,113 @@ class RichTextField extends React.Component<Props, State> {
     return Plain.deserialize('')
   }
 
+  /**
+   * On key down, if it's a formatting command toggle a mark.
+   */
+  onKeyDown = (
+    e: Event,
+    data: { isMod: boolean; key: string },
+    state: State
+  ) => {
+    if (!data.isMod) return
+    let mark
+
+    switch (data.key) {
+      case 'b':
+        mark = 'bold'
+        break
+      case 'i':
+        mark = 'italic'
+        break
+      case 'u':
+        mark = 'underlined'
+        break
+      default:
+        return
+    }
+
+    state = state.transform().toggleMark(mark).apply()
+
+    e.preventDefault()
+    return state
+  }
+
   onEditorChange = async (editorState: any) => {
+    const { onChange, id } = this.props
+    this.setState({ editorState })
+    const content = Raw.serialize(editorState)
+    onChange(content, id)
+  }
+
+  hasMark = type => {
+    const { editorState } = this.state
+    return editorState.marks.some(mark => mark.type === type)
+  }
+
+  renderMarkButton(type, icon) {
+    const isActive = this.hasMark(type)
+    const onMouseDown = e => this.onClickMark(e, type)
+
+    return (
+      <span
+        className="Toolbar-button"
+        onMouseDown={onMouseDown}
+        data-active={isActive}
+      >
+        {icon}
+        <style jsx>{`
+          .Toolbar-button {
+            display: flex;
+            margin: 4px;
+            margin-left: 12px;
+            width: 12px;
+            opacity: 0.5;
+          }
+
+          .Toolbar-button:first-child {
+            margin-left: 6px;
+          }
+
+          .Toolbar-button[data-active="true"] {
+            opacity: 1;
+          }
+        `}</style>
+      </span>
+    )
+  }
+
+  onClickMark = (e, type) => {
+    e.preventDefault()
+    let { editorState } = this.state
+
+    editorState = editorState.transform().toggleMark(type).apply()
+
     this.setState({ editorState })
   }
 
   render() {
-    const { id, value, onChange } = this.props
+    const { value, isEditing, placeholder } = this.props
     const { editorState } = this.state
-
+    if (!isEditing && !editorState.document.length) {
+      return null
+    }
     return (
       <div className="RichTextField">
         <div className="RichTextField-toolbar">
-          Toolbar here
+          {this.renderMarkButton('bold', <FaBold />)}
+          {this.renderMarkButton('italic', <FaItalic />)}
+          {this.renderMarkButton('underlined', <FaUnderline />)}
+          {this.renderMarkButton('quote', <FaQuoteRight />)}
+          {this.renderMarkButton('bulleted-list', <FaListUl />)}
+          {this.renderMarkButton('numbered-list', <FaListOl />)}
         </div>
         <div className="RichTextField-editor">
-          <SlateRenderer state={editorState} onChange={this.onEditorChange} />
+          <SlateRenderer
+            state={editorState}
+            onChange={this.onEditorChange}
+            onKeyDown={this.onKeyDown}
+            placeholder={placeholder || ''}
+          />
         </div>
         <style jsx>{`
           .RichTextField {
@@ -63,7 +170,14 @@ class RichTextField extends React.Component<Props, State> {
             flex-direction: column;
             flex-wrap: wrap;
           }
-
+          .RichTextField-toolbar {
+            border: 1px solid ${input.border};
+            border-bottom: none;
+            display: flex;
+            padding: 12px;
+            width: 100%;
+            background: #e5e6ed;
+          }
           .RichTextField-editor {
             background: #fff;
             border: 1px solid ${input.border};
@@ -72,6 +186,7 @@ class RichTextField extends React.Component<Props, State> {
             font-weight: 400;
             font-family: initial;
             line-height: 1.5;
+            min-height: 12em;
             padding: 8px;
             width: 100%;
           }
@@ -81,4 +196,4 @@ class RichTextField extends React.Component<Props, State> {
   }
 }
 
-export default RichTextField
+export default createEditable<Props>()(RichTextField)

--- a/packages/tux/src/components/fields/RichTextField.tsx
+++ b/packages/tux/src/components/fields/RichTextField.tsx
@@ -45,8 +45,8 @@ class RichTextField extends React.Component<Props> {
     return Plain.deserialize('')
   }
 
-  onChange = async (editorState: any) => {
-    const { onEditorChange } = this.props
+  onChange = async () => {
+    const { onEditorChange, editorState } = this.props
     onEditorChange(editorState)
   }
 
@@ -59,6 +59,44 @@ class RichTextField extends React.Component<Props> {
   hasMark = type => {
     const { editorState } = this.props
     return editorState.marks.some(mark => mark.type === type)
+  }
+
+  hasBlock = (type) => {
+    const { editorState } = this.props
+    return editorState.blocks.some(node => node.type === type)
+  }
+
+  renderBlockButton(type, icon) {
+    const { onClickBlock } = this.props
+    const isActive = this.hasBlock(type)
+    const onMouseDown = event => onClickBlock(event, type)
+
+    return (
+      <span
+        className="Toolbar-button"
+        onMouseDown={onMouseDown}
+        data-active={isActive}
+      >
+        {icon}
+        <style jsx>{`
+          .Toolbar-button {
+            display: flex;
+            margin: 4px;
+            margin-left: 12px;
+            width: 12px;
+            opacity: 0.5;
+          }
+
+          .Toolbar-button:first-child {
+            margin-left: 6px;
+          }
+
+          .Toolbar-button[data-active="true"] {
+            opacity: 1;
+          }
+        `}</style>
+      </span>
+    )
   }
 
   renderMarkButton(type, icon) {
@@ -94,9 +132,8 @@ class RichTextField extends React.Component<Props> {
     )
   }
 
-
   render() {
-    const { editorState, value, isEditing, placeholder, onKeyDown } = this.props
+    const { editorState, onEditorChange, value, isEditing, placeholder, onKeyDown } = this.props
     if (!isEditing && !editorState.document.length) {
       return null
     }
@@ -107,14 +144,14 @@ class RichTextField extends React.Component<Props> {
           {this.renderMarkButton('italic', <FaItalic />)}
           {this.renderMarkButton('underlined', <FaUnderline />)}
           {this.renderMarkButton('quote', <FaQuoteRight />)}
-          {this.renderMarkButton('bulleted-list', <FaListUl />)}
-          {this.renderMarkButton('numbered-list', <FaListOl />)}
+          {this.renderBlockButton('bulleted-list', <FaListUl />)}
+          {this.renderBlockButton('numbered-list', <FaListOl />)}
         </div>
         <div className="RichTextField-editor">
           <SlateRenderer
             style={{ width: '100%' }}
             state={editorState}
-            onChange={this.onChange}
+            onChange={onEditorChange}
             onKeyDown={onKeyDown}
             placeholder={placeholder || ''}
           />

--- a/packages/tux/src/components/fields/RichTextField.tsx
+++ b/packages/tux/src/components/fields/RichTextField.tsx
@@ -59,7 +59,7 @@ class RichTextField extends React.Component<Props, State> {
    * On key down, if it's a formatting command toggle a mark.
    */
   onKeyDown = (
-    e: Event,
+    event: Event,
     data: { isMod: boolean; key: string },
     state: State
   ) => {
@@ -82,7 +82,7 @@ class RichTextField extends React.Component<Props, State> {
 
     state = state.transform().toggleMark(mark).apply()
 
-    e.preventDefault()
+    event.preventDefault()
     return state
   }
 
@@ -100,7 +100,7 @@ class RichTextField extends React.Component<Props, State> {
 
   renderMarkButton(type, icon) {
     const isActive = this.hasMark(type)
-    const onMouseDown = e => this.onClickMark(e, type)
+    const onMouseDown = event => this.onClickMark(event, type)
 
     return (
       <span
@@ -130,8 +130,8 @@ class RichTextField extends React.Component<Props, State> {
     )
   }
 
-  onClickMark = (e, type) => {
-    e.preventDefault()
+  onClickMark = (event, type) => {
+    event.preventDefault()
     let { editorState } = this.state
 
     editorState = editorState.transform().toggleMark(type).apply()

--- a/packages/tux/src/components/fields/RichTextField.tsx
+++ b/packages/tux/src/components/fields/RichTextField.tsx
@@ -45,30 +45,21 @@ class RichTextField extends React.Component<Props> {
     return Plain.deserialize('')
   }
 
-  onChange = async () => {
-    const { onEditorChange, editorState } = this.props
-    onEditorChange(editorState)
-  }
-
   componentDidUpdate(oldProps) {
     if (oldProps.editorState !== this.props.editorState) {
       this.onChange()
     }
   }
 
-  hasMark = type => {
-    const { editorState } = this.props
-    return editorState.marks.some(mark => mark.type === type)
+  onChange = async () => {
+    const { onEditorChange, editorState } = this.props
+    onEditorChange(editorState)
   }
 
-  hasBlock = (type) => {
-    const { editorState } = this.props
-    return editorState.blocks.some(node => node.type === type)
-  }
 
   renderBlockButton(type, icon) {
-    const { onClickBlock } = this.props
-    const isActive = this.hasBlock(type)
+    const { onClickBlock, hasBlock } = this.props
+    const isActive = hasBlock(type)
     const onMouseDown = event => onClickBlock(event, type)
 
     return (
@@ -100,8 +91,8 @@ class RichTextField extends React.Component<Props> {
   }
 
   renderMarkButton(type, icon) {
-    const { onClickMark } = this.props
-    const isActive = this.hasMark(type)
+    const { onClickMark, hasMark } = this.props
+    const isActive = hasMark(type)
     const onMouseDown = event => onClickMark(event, type)
 
     return (

--- a/packages/tux/src/main.admin.ts
+++ b/packages/tux/src/main.admin.ts
@@ -10,6 +10,7 @@ export { default as Dropdown } from './components/fields/Dropdown'
 export { default as ImageField } from './components/fields/ImageField'
 export { default as MarkdownField } from './components/fields/MarkdownField'
 export { default as Radio } from './components/fields/Radio'
+export { default as RichTextField } from './components/fields/RichTextField'
 export { default as TagEditor } from './components/fields/TagEditor'
 export { default as Input } from './components/fields/Input'
 

--- a/packages/tux/src/main.ts
+++ b/packages/tux/src/main.ts
@@ -13,6 +13,7 @@ export const Dropdown = adminOnly('Dropdown')
 export const ImageField = adminOnly('ImageField')
 export const MarkdownField = adminOnly('MarkdownField')
 export const Radio = adminOnly('Radio')
+export const RichTextField = adminOnly('RichTextField')
 export const TagEditor = adminOnly('TagEditor')
 export const Input = adminOnly('Input')
 

--- a/packages/tux/src/utils/slate.ts
+++ b/packages/tux/src/utils/slate.ts
@@ -1,0 +1,93 @@
+import { Html as HtmlSerializer } from 'slate'
+
+/**
+ * Tags to blocks.
+ */
+const BLOCK_TAGS : { [key: string]: string } = {
+  p: 'paragraph',
+  li: 'list-item',
+  ul: 'bulleted-list',
+  ol: 'numbered-list',
+  blockquote: 'quote',
+  pre: 'code',
+  h1: 'heading-one',
+  h2: 'heading-two',
+  h3: 'heading-three',
+  h4: 'heading-four',
+  h5: 'heading-five',
+  h6: 'heading-six'
+}
+
+/**
+ * Tags to marks.
+ */
+const MARK_TAGS : { [key: string]: string } = {
+  strong: 'bold',
+  em: 'italic',
+  u: 'underline',
+  s: 'strikethrough',
+  code: 'code'
+}
+
+/**
+ * Serializer rules.
+ */
+const RULES = [
+  {
+    deserialize(el, next) {
+      const block = BLOCK_TAGS[el.tagName.toLowerCase()]
+      if (!block) return
+      return {
+        kind: 'block',
+        type: block,
+        nodes: next(el.childNodes)
+      }
+    }
+  },
+  {
+    deserialize(el, next) {
+      const mark = MARK_TAGS[el.tagName.toLowerCase()]
+      if (!mark) return
+      return {
+        kind: 'mark',
+        type: mark,
+        nodes: next(el.childNodes)
+      }
+    }
+  },
+  {
+    // Special case for code blocks, which need to grab the nested childNodes.
+    deserialize(el, next) {
+      if (el.tagName.toLowerCase() !== 'pre') return
+      const code = el.childNodes[0]
+      const childNodes = code && code.tagName.toLowerCase() === 'code'
+        ? code.childNodes
+        : el.childNodes
+
+      return {
+        kind: 'block',
+        type: 'code',
+        nodes: next(childNodes)
+      }
+    }
+  },
+  {
+    // Special case for links, to grab their href.
+    deserialize(el, next) {
+      if (el.tagName.toLowerCase() !== 'a') return
+      return {
+        kind: 'inline',
+        type: 'link',
+        nodes: next(el.childNodes),
+        data: {
+          href: el.getAttribute('href'),
+        }
+      }
+    }
+  }
+]
+
+/**
+ * Create a new HTML serializer with `RULES`.
+ */
+export const Html = new HtmlSerializer({ rules: RULES })


### PR DESCRIPTION
Moved Slate serializer functionality to utils/slate.

Added RichTextField to handle `widgetId: objectEditor`, with toolbar.

Made a higher order component for `Editor` components that need the ability to modify `Slate` state.

![image](https://user-images.githubusercontent.com/8494120/29269173-b23fb0fa-80df-11e7-976a-e4bf7dd30bc6.png)