### PR TITLE
Entries should have content type ID from Contentful

### DIFF
--- a/packages/tux-adapter-contentful/src/query-api.spec.ts
+++ b/packages/tux-adapter-contentful/src/query-api.spec.ts
@@ -76,6 +76,7 @@ describe('query entries', () => {
 
     const [{ entry: listItem }] = entry.fields.list
     expect(listItem.heading).toEqual('This is a list item with an image')
+    expect(listItem._contentType).toEqual('item')
     expect(listItem.image.asset.title).toEqual('Image title')
     expect(listItem.image.asset.file.url).toEqual('//path-to-image.jpg')
   })

--- a/packages/tux-adapter-contentful/src/query-api.spec.ts
+++ b/packages/tux-adapter-contentful/src/query-api.spec.ts
@@ -76,7 +76,7 @@ describe('query entries', () => {
 
     const [{ entry: listItem }] = entry.fields.list
     expect(listItem.heading).toEqual('This is a list item with an image')
-    expect(listItem._contentType).toEqual('item')
+    expect(listItem.sys.contentType.sys.id).toEqual('item')
     expect(listItem.image.asset.title).toEqual('Image title')
     expect(listItem.image.asset.file.url).toEqual('//path-to-image.jpg')
   })

--- a/packages/tux-adapter-contentful/src/query-api.ts
+++ b/packages/tux-adapter-contentful/src/query-api.ts
@@ -73,14 +73,12 @@ class QueryApi {
   private populateLinks(links: ContentfulJsonItem[], linkMap: LinkMap) {
     for (const asset of links) {
       if (!asset.sys) {
-        return;
+        return
       }
 
       const entry = this.checkOverride(asset)
       const { fields } = entry
-      if (entry.sys.contentType) {
-        fields._contentType = entry.sys.contentType.sys.id
-      }
+      fields.sys = entry.sys
       linkMap[entry.sys.id] = fields
     }
   }

--- a/packages/tux-adapter-contentful/src/query-api.ts
+++ b/packages/tux-adapter-contentful/src/query-api.ts
@@ -6,6 +6,11 @@ export interface ContentfulJsonItem {
   sys: {
     id: string,
     updatedAt: string,
+    contentType: {
+      sys: {
+        id: string
+      }
+    }
   }
   fields: any,
 }
@@ -67,9 +72,16 @@ class QueryApi {
 
   private populateLinks(links: ContentfulJsonItem[], linkMap: LinkMap) {
     for (const asset of links) {
-      if (asset.sys) {
-        linkMap[asset.sys.id] = this.checkOverride(asset).fields
+      if (!asset.sys) {
+        return;
       }
+
+      const entry = this.checkOverride(asset)
+      const { fields } = entry
+      if (entry.sys.contentType) {
+        fields._contentType = entry.sys.contentType.sys.id
+      }
+      linkMap[entry.sys.id] = fields
     }
   }
 


### PR DESCRIPTION
Add `_contentType` from Contentful to entries. It’s prefixed with `_` to avoid name collision with other fields.