### PR TITLE
Rename Contentful clientId to applicationUid

### DIFF
--- a/packages/tux-adapter-contentful/src/adapter.admin.ts
+++ b/packages/tux-adapter-contentful/src/adapter.admin.ts
@@ -151,7 +151,7 @@ export class ContentfulAdapter extends BaseAdapter implements Adapter {
   async login() {
     location.href =
       `https://be.contentful.com/oauth/authorize?response_type=token&` +
-      `client_id=${this.clientId}&redirect_uri=${this
+      `client_id=${this.applicationUid}&redirect_uri=${this
         .redirectUri}&scope=content_management_manage`
   }
 

--- a/packages/tux-adapter-contentful/src/base-adapter.ts
+++ b/packages/tux-adapter-contentful/src/base-adapter.ts
@@ -4,19 +4,20 @@ export interface Config {
   space: string
   accessToken: string
   host: string
-  clientId: string
+  applicationUid: string
+  clientId: string // Deprecated
   redirectUri: string
 }
 
 export default class BaseAdapter {
   deliveryApi: QueryApi
   space: string
-  clientId: string
+  applicationUid: string
   redirectUri: string
 
   constructor(config: Config) {
     this.space = config.space
-    this.clientId = config.clientId
+    this.applicationUid = config.applicationUid || config.clientId
     this.redirectUri = config.redirectUri
     this.deliveryApi = QueryApi.create(
       config.space,

--- a/packages/tux-example-site/src/app.js
+++ b/packages/tux-example-site/src/app.js
@@ -21,8 +21,8 @@ const adapter = createContentfulAdapter({
   accessToken:
     process.env.TUX_CONTENTFUL_ACCESS_TOKEN ||
     '61344f3579f7f80450ffc4bc7111624e1035c9588e9680c02519bce08bbbc3ca',
-  clientId:
-    process.env.TUX_CONTENTFUL_CLIENT_ID ||
+  applicationUid:
+    process.env.TUX_CONTENTFUL_APPLICATION_UID ||
     '5be3eeb398764037af2e860d1933bc9518d2f71a72cade411c5f5260e8dd9335',
   host: 'preview.contentful.com',
   redirectUri: publicUrl,

--- a/packages/tux-scripts/template/new/src/app.js
+++ b/packages/tux-scripts/template/new/src/app.js
@@ -13,11 +13,12 @@ const publicUrl = process.env.PUBLIC_URL
       ? `https://localhost:${process.env.PORT || '5000'}`
       : `${location.protocol}//${location.host}/`;
 
-// Get your Contentful clientId (application Uid) from https://app.contentful.com/account/profile/developers/applications
+// Get your Contentful application uid from
+// https://app.contentful.com/account/profile/developers/applications
 const adapter = createContentfulAdapter({
   space: process.env.TUX_CONTENTFUL_SPACE_ID,
   accessToken: process.env.TUX_CONTENTFUL_ACCESS_TOKEN,
-  clientId: process.env.TUX_CONTENTFUL_CLIENT_ID,
+  applicationUid: process.env.TUX_CONTENTFUL_APPLICATION_UID,
   redirectUri: publicUrl,
 });
 


### PR DESCRIPTION
To match the language in Contentful's UI.

Fixes #109 